### PR TITLE
Fix specification of run directories

### DIFF
--- a/spaceKLIP/companion.py
+++ b/spaceKLIP/companion.py
@@ -63,6 +63,9 @@ def extract_companions(meta):
 
     # Loop through directories of subtracted images
     for counter, rdir in enumerate(meta.rundirs):
+        # Check if run directory actually exists
+        if not os.path.exists(rdir):
+            raise ValueError('Could not find provided run directory "{}"'.format(rdir))
 
         # Get the mode from the saved meta file
         metasave = io.read_metajson(rdir+'SUBTRACTED/MetaSave.json')

--- a/spaceKLIP/companion.py
+++ b/spaceKLIP/companion.py
@@ -149,7 +149,7 @@ def extract_companions(meta, recenter_offsetpsf=False, use_fm_psf=True):
                                                  input_wvs=input_wvs,
                                                  spectrallib=[guess_spec],
                                                  spectrallib_units='contrast',
-                                                 field_dependent_correction=partial(utils.field_dependent_correction, meta=meta, key=key))
+                                                 field_dependent_correction=partial(utils.field_dependent_correction, meta=meta))
                     
                     # Compute the forward-modeled dataset.
                     annulus = [[guess_sep-20., guess_sep+20.]] # pix
@@ -203,7 +203,7 @@ def extract_companions(meta, recenter_offsetpsf=False, use_fm_psf=True):
                     xx = np.arange(sx)-sx//2-(int(guess_dx)+(fm_centx-int(fm_centx)))
                     yy = np.arange(sy)-sy//2+(int(guess_dy)-(fm_centy-int(fm_centy)))
                     stamp_dx, stamp_dy = np.meshgrid(xx, yy)
-                    stamp = utils.field_dependent_correction(stamp, stamp_dx, stamp_dy, meta, key)
+                    stamp = utils.field_dependent_correction(stamp, stamp_dx, stamp_dy, meta)
                     fm_frame[:, :] = 0.
                     fm_frame[int(fm_centy)+int(guess_dy)-sy//2:int(fm_centy)+int(guess_dy)+sy//2+1, int(fm_centx)-int(guess_dx)-sx//2:int(fm_centx)-int(guess_dx)+sx//2+1] = stamp
                 

--- a/spaceKLIP/contrast.py
+++ b/spaceKLIP/contrast.py
@@ -292,7 +292,7 @@ def calibrated_contrast_curve(meta):
             if meta.plotting:
                 # Plot injected locations
                 savefile=odir+key+'-cons_inj.pdf'
-                plotting.plot_injected_locs(meta, data, tottp, seps_all, pas_all, pxsc=None, savefile=savefile)
+                plotting.plot_injected_locs(meta, data, tottp, seps_all, pas_all, pxsc=pxsc, savefile=savefile)
 
                 # Plot calibrated contrast
                 fit_thrput = {}

--- a/spaceKLIP/contrast.py
+++ b/spaceKLIP/contrast.py
@@ -48,7 +48,12 @@ def raw_contrast_curve(meta):
         print('--> Computing raw contrast curve...')
 
     # Loop through directories of subtracted images
-    for counter, rdir in enumerate(meta.rundirs):
+    for counter, rdir in enumerate(meta.rundirs): 
+        # Check if run directory actually exists
+        if not os.path.exists(rdir):
+            raise ValueError('Could not find provided run directory "{}"'.format(rdir))
+
+
         if meta.verbose:
             dirparts = rdir.split('/')[-2].split('_') # -2 because of trailing '/'
             print('--> Mode = {}, annuli = {}, subsections = {}, scenario {} of {}'.format(dirparts[3], dirparts[4], dirparts[5], counter+1, len(meta.rundirs)))
@@ -173,6 +178,10 @@ def calibrated_contrast_curve(meta):
     # subsections.
     meta.truenumbasis = {}
     for counter, rdir in enumerate(meta.rundirs):
+        # Check if run directory actually exists
+        if not os.path.exists(rdir):
+            raise ValueError('Could not find provided run directory "{}"'.format(rdir))
+
         # Get some information from the original meta file in the run directory
         metasave = io.read_metajson(rdir+'SUBTRACTED/MetaSave.json')
         mode = metasave['used_mode']

--- a/spaceKLIP/contrast.py
+++ b/spaceKLIP/contrast.py
@@ -248,7 +248,7 @@ def calibrated_contrast_curve(meta):
             # 2D map of the total throughput, i.e., an integration
             # time weighted average of the coronmsk transmission
             # over the rolls.
-            tottp = utils.get_transmission(meta, pxsc, filt, mask, subarr, odir, key)
+            tottp = utils.get_transmission(meta, key, odir)
             
             # The calibrated contrast curves have not been
             # computed already.
@@ -258,7 +258,7 @@ def calibrated_contrast_curve(meta):
                 # time weighted average of the unocculted offset
                 # PSF over the rolls (does account for pupil mask
                 # throughput).
-                offsetpsf = utils.get_offsetpsf(meta, inst, filt, mask, key)
+                offsetpsf = utils.get_offsetpsf(meta, key, recenter_offsetpsf=False, derotate=True)
                 
                 # Convert the units and compute the injected
                 # fluxes. They need to be in the units of the data
@@ -500,7 +500,7 @@ def inject_recover(meta,
     # Offset PSF from WebbPSF, i.e., an integration time weighted average
     # of the unocculted offset PSF over the rolls (normalized to a peak
     # flux of 1).
-    offsetpsf = utils.get_offsetpsf(meta, inst, filt, mask, key)
+    offsetpsf = utils.get_offsetpsf(meta, key, recenter_offsetpsf=False, derotate=True)
     offsetpsf /= np.max(offsetpsf)
     
     # Initialize outputs.
@@ -552,7 +552,7 @@ def inject_recover(meta,
                         todo += [i*Npa+j]
                         done += [i*Npa+j]
                         stamp = np.array([offsetpsf*flux_inject[i] for k in range(dataset.input.shape[0])]) # MJy/sr
-                        fakes.inject_planet(frames=dataset.input, centers=dataset.centers, inputflux=stamp, astr_hdrs=dataset.wcs, radius=seps_inject[i], pa=pas_inject[j], field_dependent_correction=partial(utils.correct_transmission, meta=meta))
+                        fakes.inject_planet(frames=dataset.input, centers=dataset.centers, inputflux=stamp, astr_hdrs=dataset.wcs, radius=seps_inject[i], pa=pas_inject[j], field_dependent_correction=partial(utils.field_dependent_correction, meta=meta))
                         flux_all += [flux_inject[i]] # MJy/sr
                         seps_all += [seps_inject[i]] # pix
                         pas_all += [pas_inject[j]] # deg

--- a/spaceKLIP/engine.py
+++ b/spaceKLIP/engine.py
@@ -1,15 +1,9 @@
-<<<<<<< HEAD
-import glob, os, re
-=======
 from __future__ import division
-
-
 # =============================================================================
 # IMPORTS
 # =============================================================================
 
-import os
->>>>>>> main
+import glob, os, re
 
 import astropy.io.fits as pyfits
 import matplotlib.pyplot as plt

--- a/spaceKLIP/engine.py
+++ b/spaceKLIP/engine.py
@@ -62,6 +62,9 @@ class Pipeline():
             setattr(self.meta, key, config[key])
 
         if self.meta.rundirs != None:
+            print(self.meta.rundirs)
+            if len(self.meta.rundirs) == 0:
+                print('WARNING: No run directory(ies) specified, using all run directories in output directory. Are you sure you want to do this?')
             self.meta.rundirs = [self.meta.odir+rdir.replace('/', '')+'/' for rdir in self.meta.rundirs]
 
         return

--- a/spaceKLIP/engine.py
+++ b/spaceKLIP/engine.py
@@ -1,4 +1,4 @@
-import os, re
+import glob, os, re
 
 import astropy.io.fits as pyfits
 import numpy as np
@@ -61,11 +61,13 @@ class Pipeline():
         for key in config:
             setattr(self.meta, key, config[key])
 
-        if self.meta.rundirs != None:
-            print(self.meta.rundirs)
+        # Assign run directories from output folder. These will be overwritten if subtraction if performed. 
+        if (self.meta.rundirs != None) or (len(self.meta.rundirs) == 0):
             if len(self.meta.rundirs) == 0:
-                print('WARNING: No run directory(ies) specified, using all run directories in output directory. Are you sure you want to do this?')
-            self.meta.rundirs = [self.meta.odir+rdir.replace('/', '')+'/' for rdir in self.meta.rundirs]
+                print('WARNING: No run directory(ies) specified, looping over all run directories in output directory. Are you sure you want to do this?')
+                self.meta.rundirs = [i+'/' for i in glob.glob(self.meta.odir+'*run*')]
+            else:
+                self.meta.rundirs = [self.meta.odir+rdir.replace('/', '')+'/' for rdir in self.meta.rundirs]
 
         return
 

--- a/spaceKLIP/io.py
+++ b/spaceKLIP/io.py
@@ -215,7 +215,6 @@ def extract_obs(meta, fitsfiles_all):
             else:
                 PIXSCALE[i] = nrc._pixelscale_short*1e3 # mas
 
-            PA_V3[i] = hdul[1].header['ROLL_REF'] # deg
         elif (INSTRUME[i] == 'MIRI'):
             PIXSCALE[i] = mir.pixelscale*1e3 # mas
         else:

--- a/spaceKLIP/io.py
+++ b/spaceKLIP/io.py
@@ -176,7 +176,7 @@ def extract_obs(meta, fitsfiles_all):
                 PIXSCALE[i] = nrc._pixelscale_long*1e3 # mas
             else:
                 PIXSCALE[i] = nrc._pixelscale_short*1e3 # mas
-            PA_V3[i] = head['ROLL_REF'] # deg
+            PA_V3[i] = hdul[1].header['ROLL_REF'] # deg
         # MIRI specific settings
         elif 'MIRI' in INSTRUME[i]:
             APERNAME[i] = None

--- a/spaceKLIP/plotting.py
+++ b/spaceKLIP/plotting.py
@@ -92,12 +92,18 @@ def plot_injected_locs(meta, data, transmission, seps, pas, pxsc=None, savefile=
     #Set some quick information depending on whether a pixel scale was passed
     if pxsc == None:
         extent=(-0.5, data.shape[1]-0.5, data.shape[1]-0.5, -0.5)
+        extent_tr=(-0.5, transmission.shape[1]-0.5, transmission.shape[1]-0.5, -0.5)
         pxsc = 1
         xlabel, ylabel = 'Pixels', 'Pixels'
     else:
         extl = (data.shape[1]+1.)/2.*pxsc/1000. # arcsec
         extr = (data.shape[1]-1.)/2.*pxsc/1000. # arcsec
         extent = (extl, -extr, -extl, extr)
+
+        extl = (transmission.shape[1]/2.)*pxsc/1000 # arcsec
+        extr = (transmission.shape[1]/2.)*pxsc/1000 # arcsec
+        extent_tr = (extl, -extr, -extl, extr)
+
         xlabel, ylabel = '$\Delta$RA [arcsec]', '$\Delta$DEC [arcsec]'
 
     f, ax = plt.subplots(1, 2, figsize=(2*6.4, 1*4.8))
@@ -110,16 +116,13 @@ def plot_injected_locs(meta, data, transmission, seps, pas, pxsc=None, savefile=
         de = seps[i]*pxsc*np.cos(np.deg2rad(pas[i])) # mas
         cc = plt.Circle((ra/1000., de/1000.), 10.*pxsc/1000., fill=False, edgecolor='red', linewidth=3)
         ax[0].add_artist(cc)
-    ax[0].set_xlim([5., -5.])
-    ax[0].set_ylim([-5., 5.])
+    # ax[0].set_xlim([5., -5.])
+    # ax[0].set_ylim([-5., 5.])
     ax[0].set_xlabel(xlabel)
     ax[0].set_ylabel(ylabel)
     ax[0].set_title('KLIP-subtracted')
 
-    extl = transmission.shape[1]/2.*pxsc/1000. # arcsec
-    extr = transmission.shape[1]/2.*pxsc/1000. # arcsec
-    extent = (extl, -extr, -extl, extr)
-    p1 = ax[1].imshow(transmission, origin='lower', cmap='viridis', vmin=0., vmax=1., extent=extent)
+    p1 = ax[1].imshow(transmission, origin='lower', cmap='viridis', vmin=0., vmax=1., extent=extent_tr)
     c1 = plt.colorbar(p1, ax=ax[1])
     c1.set_label('Transmission', rotation=270, labelpad=20)
     for i in range(len(meta.ra_off)):
@@ -130,10 +133,10 @@ def plot_injected_locs(meta, data, transmission, seps, pas, pxsc=None, savefile=
         de = seps[i]*pxsc*np.cos(np.deg2rad(pas[i])) # mas
         cc = plt.Circle((ra/1000., de/1000.), 10.*pxsc/1000., fill=False, edgecolor='red', linewidth=3)
         ax[1].add_artist(cc)
-    ax[1].set_xlim([5., -5.])
-    ax[1].set_ylim([-5., 5.])
-    ax[1].set_xlabel('$\Delta$RA [arcsec]')
-    ax[1].set_ylabel('$\Delta$DEC [arcsec]')
+    # ax[1].set_xlim([5., -5.])
+    # ax[1].set_ylim([-5., 5.])
+    ax[1].set_xlabel(xlabel)
+    ax[1].set_ylabel(ylabel)
     ax[1].set_title('Transmission')
     plt.tight_layout()
     plt.savefig(savefile)

--- a/spaceKLIP/rampfit.py
+++ b/spaceKLIP/rampfit.py
@@ -23,7 +23,7 @@ def stsci_ramp_fitting(meta):
 		pipeline.output_dir = meta.odir + 'RAMPFIT/'
 
 		if os.path.exists(pipeline.output_dir) == False:
-			    os.mkdir(pipeline.output_dir)
+			os.makedirs(pipeline.output_dir)
 		pipeline.run(file)
 
 	return

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -347,8 +347,7 @@ def get_transmission(meta, key, odir, derotate=False):
 def field_dependent_correction(stamp,
                                stamp_dx,
                                stamp_dy,
-                               meta,
-                               key):
+                               meta):
     """
     Apply the coronagraphic mask transmission to a PSF stamp.
     

--- a/tests/example_config.yaml
+++ b/tests/example_config.yaml
@@ -15,7 +15,7 @@ odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220606/' 
 sdir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/HIP65426.vot' #VOT table or stellar model file.
 
 ##### OPTIONAL #####
-rundirs: ['2022_04_27_RDI_annu1_subs1_run1'] #Specify directory(ies) within odir of existing runs to calculate contrast cuvre / companion
+rundirs: [] #'2022_06_06_RDI_annu1_subs1_run1'] #Specify directory(ies) within odir of existing runs to calculate contrast cuvre / companion
 ancildir: None      # Specify directory to save ancillary files, if None then saved under odir/ANCILLARY/. 
 
 ############################

--- a/tests/example_config.yaml
+++ b/tests/example_config.yaml
@@ -9,9 +9,9 @@
 #######################
 
 ##### REQUIRED #####
- # Input Directory 
-idir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/HIFI_SIMS/NIRCam/20220407/small_uncal/'
-odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220606/' # Output Directory
+# Input Directory 
+idir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/HIFI_SIMS/NIRCam/20220407/pynrc_data/'
+odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220608/' # Output Directory
 sdir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/HIP65426.vot' #VOT table or stellar model file.
 
 ##### OPTIONAL #####
@@ -31,8 +31,8 @@ overwrite: True   # Will overwrite existing files in a given directory
 ##### Star / Companion information #####
 ########################################
 spt: 'A2V' # Spectral type of target, only necessary for VOTable. Keep it simple.
-ra_off: [418.] # mas; RA offset of the known companions in the same order as in the NIRCCoS config file
-de_off: [-698.] # mas; DEC offset of the known companions in the same order as in the NIRCCoS config file
+ra_off: [418.] # mas; RA offset of the known companions
+de_off: [-698.] # mas; DEC offset of the known companions 
 
 #################################
 ##### Ramp Fitting Settings #####

--- a/tests/example_config.yaml
+++ b/tests/example_config.yaml
@@ -10,8 +10,8 @@
 
 ##### REQUIRED #####
 # Input Directory 
-idir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/HIFI_SIMS/NIRCam/20220407/pynrc_data/'
-odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220608/' # Output Directory
+idir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/HIFI_SIMS/NIRCam/20220407/small_uncal/'
+odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220614/' # Output Directory
 sdir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/HIP65426.vot' #VOT table or stellar model file.
 
 ##### OPTIONAL #####

--- a/tests/example_config.yaml
+++ b/tests/example_config.yaml
@@ -10,8 +10,8 @@
 
 ##### REQUIRED #####
  # Input Directory 
-idir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/HIFI_SIMS/MIRI/Elodie_20220420/'
-odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/TESTING_MIRI/' # Output Directory
+idir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/HIFI_SIMS/NIRCam/20220407/small_uncal/'
+odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220606/' # Output Directory
 sdir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/HIP65426.vot' #VOT table or stellar model file.
 
 ##### OPTIONAL #####

--- a/tests/example_config.yaml
+++ b/tests/example_config.yaml
@@ -61,6 +61,7 @@ numbasis: [1, 2, 5, 10, 20, 50, 100] # list of number of basis vectors for pyKLI
 KL: -1 # index of the KL component for which the calibrated contrast curve and the companion properties shall be computed
 
 seps_inject_rnd: [5.0, 7.5, 10.0, 12.5, 15.0, 17.5, 20.0, 25., 30.0, 35.0, 40.0] # pix; list of separations at which fake planets shall be injected to compute the calibrated contrast curve for the round masks
+#seps_inject_rnd: [5.0, 25.0, 40.0] # pix; list 
 pas_inject_rnd: [0., 45., 90., 135., 180., 225., 270., 315.] # deg; list of position angles at which fake planets shall be injected to compute the calibrated contrast curve for the round masks
 
 pa_ranges_bar: [(105, 105), (285, 285)] # deg; list of tuples defining the pizza slices that shall be considered when computing the contrast curves for the bar masks

--- a/tests/run_pipeline.py
+++ b/tests/run_pipeline.py
@@ -1,7 +1,5 @@
 import os, sys
 sys.path.append('..')
-os.environ['CRDS_PATH'] = '../crds_cache'
-os.environ['CRDS_SERVER_URL'] = 'https://jwst-crds.stsci.edu'
 from spaceKLIP.engine import JWST
 
 config_file = os.path.dirname(__file__)+'/example_config.yaml'

--- a/tests/run_pipeline.py
+++ b/tests/run_pipeline.py
@@ -6,9 +6,9 @@ from spaceKLIP.engine import JWST
 config_file = os.path.dirname(__file__)+'/example_config.yaml'
 if __name__ == '__main__':
 	pipe = JWST(config_file)
-	pipe.run_all(skip_ramp=False, 
-				 skip_imgproc=False, 
-				 skip_sub=False, 
-				 skip_rawcon=False, 
+	pipe.run_all(skip_ramp=True, 
+				 skip_imgproc=True, 
+				 skip_sub=True, 
+				 skip_rawcon=True, 
 				 skip_calcon=False, 
 				 skip_comps=False)

--- a/tests/run_pipeline.py
+++ b/tests/run_pipeline.py
@@ -6,9 +6,9 @@ from spaceKLIP.engine import JWST
 config_file = os.path.dirname(__file__)+'/example_config.yaml'
 if __name__ == '__main__':
 	pipe = JWST(config_file)
-	pipe.run_all(skip_ramp=True, 
-				 skip_imgproc=True, 
-				 skip_sub=True, 
+	pipe.run_all(skip_ramp=False, 
+				 skip_imgproc=False, 
+				 skip_sub=False, 
 				 skip_rawcon=False, 
-				 skip_calcon=True, 
-				 skip_comps=True)
+				 skip_calcon=False, 
+				 skip_comps=False)

--- a/tests/run_pipeline.py
+++ b/tests/run_pipeline.py
@@ -6,9 +6,9 @@ from spaceKLIP.engine import JWST
 config_file = os.path.dirname(__file__)+'/example_config.yaml'
 if __name__ == '__main__':
 	pipe = JWST(config_file)
-	pipe.run_all(skip_ramp=False, 
-				 skip_imgproc=False, 
-				 skip_sub=False, 
+	pipe.run_all(skip_ramp=True, 
+				 skip_imgproc=True, 
+				 skip_sub=True, 
 				 skip_rawcon=False, 
-				 skip_calcon=False, 
-				 skip_comps=False)
+				 skip_calcon=True, 
+				 skip_comps=True)


### PR DESCRIPTION
A couple of quick fixes:

- Specifiying run directories will now correctly use that run directory, OR if the run directory is invalid then no folder will be created and warning will be shown. If the rundir list is empty, then all run directories are used. 
- Fixed the _inj plot from the calibrated contrast stage. 