### PR TITLE
Coron1Detector subclass for ramp fitting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,9 @@ flycheck_*.el
 
 # directory configuration
 .dir-locals.el
+
+# Local stuff
+crds_cache
+tests/data/*
+tests/ultranest
+tests/species_*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,201 @@
-.DS_store
-
+# Byte-compiled / optimized / DLL files
 __pycache__/
-crds_cache
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+_*.ipynb
+Untitled*.ipynb
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Visual Studio Code
+.vscode
+
+# Icon must end with two \r
+Icon
+# Thumbnails
+._*
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el

--- a/spaceKLIP/psf.py
+++ b/spaceKLIP/psf.py
@@ -10,6 +10,8 @@ from webbpsf_ext import NIRCam_ext, MIRI_ext
 
 webbpsf_ext.setup_logging('WARN')
 
+# Progress bar
+from tqdm.auto import trange, tqdm
 
 class JWST_PSF():
     
@@ -94,8 +96,8 @@ class JWST_PSF():
             func_off = inst_off.calc_psf_from_coeff
             inst_on.gen_wfemask_coeff(large_grid=True)
         else:
-            func_on = psf_on.calc_psf
-            func_off = psf_off.calc_psf
+            func_on = inst_on.calc_psf
+            func_off = inst_off.calc_psf
             inst_on.options['jitter'] = 'gaussian'
             inst_on.options['jitter_sigma'] = 0.003
             inst_off.options['jitter'] = 'gaussian'
@@ -281,6 +283,8 @@ class JWST_PSF():
             If True, will offset PSF by appropriate amount from center. Otherwise,
             returns PSF in center of image.
         """
+
+        from scipy.interpolate import interp1d
 
         # Work with oversampled pixels and downsample at end
         siaf_ap = self.inst_on.siaf_ap

--- a/spaceKLIP/rampfit.py
+++ b/spaceKLIP/rampfit.py
@@ -1,7 +1,255 @@
 import os, glob
+
+import numpy as np
+from datetime import datetime
+
 from jwst.pipeline.calwebb_detector1 import Detector1Pipeline
+from jwst.datamodels import dqflags, RampModel
+
+# Define logging
+import logging
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+
+class Coron1Pipeline(Detector1Pipeline):
+    """ Coron1Pipeline
+    
+    Apply all calibration steps to raw JWST ramps to produce 
+    a 2-D slope product. Custom sub-class of ``Detector1Pipeline`` 
+    with modifications for coronagraphic data.
+    
+    Included steps are: group_scale, dq_init, saturation, ipc, 
+    superbias, refpix, rscd, firstframe, lastframe, linearity, 
+    dark_current, reset, persistence, jump detection, ramp_fit, 
+    and gain_scale. 
+    """
+
+    class_alias = "calwebb_coron1"
+
+    spec = """
+        nrow_ref           = integer(default=20)    # Number of rows for pseudo-ref correction
+        grow_diagonal      = boolean(default=False) # Grow saturation along diagonal pixels?
+        save_intermediates = boolean(default=False) # Save all intermediate step results
+    """
+    
+    # start the actual processing
+    def process(self, input):
+        
+       
+        log.info(f'Starting {self.class_alias} ...')
+
+        # open the input as a RampModel
+        input = RampModel(input)
+
+        instrument = input.meta.instrument.name
+        if instrument == 'MIRI':
+
+            # process MIRI exposures;
+            # the steps are in a different order than NIR
+            log.debug('Processing a MIRI exposure')
+
+            input = self.run_step(self.group_scale, input)
+            input = self.run_step(self.dq_init, input)
+            input = self.run_step(self.saturation, input)
+            input = self.run_step(self.ipc, input)
+            input = self.run_step(self.firstframe, input)
+            input = self.run_step(self.lastframe, input)
+            input = self.run_step(self.reset, input)
+            input = self.run_step(self.linearity, input)
+            input = self.run_step(self.rscd, input)
+            input = self.run_step(self.dark_current, input)
+            input = self.run_step(self.refpix, input)
+
+            # skip until MIRI team has figured out an algorithm
+            # input = self.persistence(input)
+
+        else:
+
+            # process Near-IR exposures
+            log.debug('Processing a Near-IR exposure')
+
+            input = self.run_step(self.group_scale, input)
+            input = self.run_step(self.dq_init, input)
+            input = self.do_saturation(input)
+            input = self.run_step(self.ipc, input)
+            input = self.run_step(self.superbias, input)
+            input = self.do_nircam_refpix(input)
+            input = self.run_step(self.linearity, input)
+            input = self.run_step(self.persistence, input)
+            input = self.run_step(self.dark_current, input)
+
+        # apply the jump step
+        input = self.run_step(self.jump, input, save_results=False)
+
+        # save the corrected ramp data, if requested
+        if self.save_calibrated_ramp or self.save_intermediates:
+            self.save_model(input, suffix='ramp')
+
+        # Apply the ramp_fit step
+        # This explicit test on self.ramp_fit.skip is a temporary workaround
+        # to fix the problem that the ramp_fit step ordinarily returns two
+        # objects, but when the step is skipped due to `skip = True`,
+        # only the input is returned when the step is invoked.
+        # Don't save results here, as it's basically the same as rate and rateints.
+        res = self.run_step(self.ramp_fit, input, save_results=False)
+        input, ints_model = (res, None) if self.ramp_fit.skip else res
+
+        if input is None:
+            log.info("NoneType returned from ramp_fit.  Gain Scale step skipped.")                
+        else:
+            # apply the gain_scale step to the exposure-level product
+            self.gain_scale.suffix = 'rate'
+            # Don't save here. Generally saved on output of run() or call().
+            input = self.run_step(self.gain_scale, input, save_results=False)
+
+        # apply the gain scale step to the multi-integration product,
+        # if it exists, and then save it
+        if ints_model is not None:
+            self.gain_scale.suffix = 'rateints'
+            ints_model = self.run_step(self.gain_scale, ints_model, save_results=False)
+            if self.save_results or self.save_intermediates:
+                self.save_model(ints_model, suffix='rateints')
+
+        # setup output_file for saving
+        self.setup_output(input)
+
+        log.info(f'... ending {self.class_alias}')
+
+        return input
+
+
+    def run_step(self, step_obj, input, save_results=None, **kwargs):
+        """Run a Step with option to save results. 
+		
+		Saving results tends to increase memory usage due to a memory leak
+		in the datamodels.
+		"""
+
+        # Determine if we're saving results for real
+        if step_obj.skip:
+            # Skip save if step is skipped
+            really_save_results = False
+        elif (save_results is not None):
+            # Use keyword specifications
+            really_save_results = save_results
+        elif self.save_intermediates:
+            # Use save_intermediates attribute
+            really_save_results = True
+        elif step_obj.save_results:
+            # Use step attribute
+            really_save_results = True
+        else:
+            # Saving is unspecified
+            really_save_results = False
+
+        # Run step. Don't save yet.
+        step_save_orig = step_obj.save_results
+        step_obj.save_results = False
+        res = step_obj(input)
+        step_obj.save_results = step_save_orig
+        
+        # Check if certain steps were skipped
+        if step_obj is self.group_scale:
+            if res.meta.cal_step.group_scale == 'SKIPPED':
+                really_save_results = False
+        elif step_obj is self.gain_scale:
+            if res.meta.cal_step.gain_scale == 'SKIPPED':
+                really_save_results = False
+        
+        # Now save results if asked
+        if really_save_results:
+            step_obj.output_dir = self.output_dir
+            if isinstance(res, (tuple)):
+                self.save_model(res[0], suffix=step_obj.suffix+'0')
+                self.save_model(res[1], suffix=step_obj.suffix+'1')
+            else:
+                self.save_model(res, suffix=step_obj.suffix)
+
+        return res
+    
+    def do_nircam_refpix(self, input, **kwargs):
+        """ Pseudo-Refpix for NIRCam subarrays
+        
+        If full frame or MIRI, will still run RefPix Step by default.
+        
+        Parameters
+        ==========
+        input : 
+            Data model or FITS file name.
+        
+        Keyword Args
+        ============
+        save_results : bool
+            Explictly specify whether or not to save results.
+        """
+        
+        # Slight modifications if NIRCam subarray
+        instrument = input.meta.instrument.name.lower()
+        subsize = input.meta.subarray.ysize
+        
+        # Perform normal operations if not set
+        if not (instrument=='NIRCAM' and subsize<2048):
+            return self.run_step(self.refpix, input, **kwargs)
+        
+        nrow_ref = self.nrow_ref
+        
+        # Update pixel DQ mask to manually set reference pixels
+        log.info(f'Flagging {nrow_ref} references rows at top and bottom of array')
+        input.pixeldq[0:nrow_ref,:] = input.pixeldq[0:nrow_ref,:] | dqflags.pixel['REFERENCE_PIXEL']
+        input.pixeldq[-nrow_ref:,:] = input.pixeldq[-nrow_ref:,:] | dqflags.pixel['REFERENCE_PIXEL']
+
+        res = self.run_step(self.refpix, input, **kwargs)
+
+        # Return pixel DQ back to original using bitwise AND of inverted flag
+        log.info(f'Removing reference pixel flags')
+        res.pixeldq[0:nrow_ref,:] = res.pixeldq[0:nrow_ref,:] & ~dqflags.pixel['REFERENCE_PIXEL']
+        res.pixeldq[-nrow_ref:,:] = res.pixeldq[-nrow_ref:,:] & ~dqflags.pixel['REFERENCE_PIXEL']
+        
+        return res
+    
+    def do_saturation(self, input, **kwargs):
+        """Peform custom saturation flagging"""
+        
+        # Check current setting
+        npix_grow = self.saturation.n_pix_grow_sat
+        # Just return normal if growing diagonal or set to 0
+        if self.grow_diagonal or npix_grow==0:
+            return self.run_step(self.saturation, input, **kwargs)
+        
+        # Run with 1 less pixel growth than specified
+        self.saturation.n_pix_grow_sat = npix_grow - 1
+        res = self.run_step(self.saturation, input, **kwargs)
+            
+        # Update saturation dq flags to grow in vertical and horizontal directions
+        # Performs a bitwise & in order to find flagged the saturation bits
+        mask_sat = (res.groupdq & dqflags.pixel['SATURATED']) > 0
+        
+        # Create a bunch of shifted masks
+        mask_vp1 = np.roll(mask_sat, +1, axis=-1)
+        mask_vm1 = np.roll(mask_sat, -1, axis=-1)
+        mask_hp1 = np.roll(mask_sat, +1, axis=-2)
+        mask_hm1 = np.roll(mask_sat, -1, axis=-2)
+        
+        # Zero out rows and columns that rolled over to the other side
+        mask_vp1[:,:, 0,:] = 0
+        mask_vm1[:,:,-1,:] = 0
+        mask_hp1[:,:,:, 0] = 0
+        mask_hm1[:,:,:,-1] = 0
+        
+        # Combine saturation masks
+        mask_sat = mask_sat | mask_vp1 | mask_vm1 | mask_hp1 | mask_hm1
+
+        # Do a bitwise OR of new mask with groupdq to flip saturation bit
+        res.groupdq = res.groupdq | (mask_sat * dqflags.pixel['SATURATED'])
+
+        # Clean up unused arrays
+        del mask_vp1, mask_vm1, mask_hp1, mask_hm1
+
+        return res
 
 def run_ramp_fitting(meta, idir, osubdir):
+	
+
 	search = '*' + meta.ramp_ext
 	# Get all of the files in the input directory
 	files = glob.glob(idir+search)
@@ -10,19 +258,65 @@ def run_ramp_fitting(meta, idir, osubdir):
 	# Run the pipeline on every file in a directory
 	for file in files:
 		# Set up pipeline
-		pipeline = Detector1Pipeline()
-		pipeline.jump.skip = meta.skip_jump
-		pipeline.jump.rejection_threshold = meta.jump_threshold
-		pipeline.ramp_fit.maximum_cores = meta.ramp_fit_max_cores
-		pipeline.dark_current.skip = meta.skip_dark_current
+		pipeline = Coron1Pipeline()
+
+		# Skip certain steps?
+		if hasattr(meta, 'skip_jump'):
+			pipeline.jump.skip = meta.skip_jump
+		if hasattr(meta, 'skip_dark_current'):
+			pipeline.dark_current.skip = meta.skip_dark_current
+		if hasattr(meta, 'skip_ipc'):
+			pipeline.ipc.skip = meta.skip_ipc
+		# Skip persistence step for now since it doesn't do anything
+		pipeline.persistence.skip = True
+
+		# Set some Step parameters
+		if hasattr(meta, 'jump_threshold'):
+			pipeline.jump.rejection_threshold = meta.jump_threshold
+		if hasattr(meta, 'ramp_fit_max_cores'):
+			pipeline.ramp_fit.maximum_cores = meta.ramp_fit_max_cores
+		if hasattr(meta, 'nrow_ref'):
+			pipeline.nrow_ref = meta.nrow_ref
+		if hasattr(meta, 'grow_diagonal'):
+			pipeline.nrow_ref = meta.grow_diagonal
+
+		# Options for saving intermediate results
+		if hasattr(meta, 'save_intermediates'):
+			pipeline.save_intermediates = meta.save_intermediates
 		pipeline.save_results = True
 
 		# Set up directory to save into
 		pipeline.output_dir = meta.odir + osubdir
-
 		if os.path.exists(pipeline.output_dir) == False:
 			os.makedirs(pipeline.output_dir)
-		pipeline.run(file)
+
+		# Create log file output
+		file_base = os.path.basename(file).replace('uncal.fits', '')
+		date_str = datetime.now().isoformat()
+		fname = f'{file_base}_detector1_{date_str}.log'
+		log_file = os.path.join(pipeline.output_dir, fname)
+		# Create empty file
+		with open(log_file, 'w') as f:
+			pass
+
+		# Add file stream handler to also append log messages to file
+		logger = logging.getLogger()
+		fh = logging.FileHandler(log_file, 'a')
+		fmt = logging.Formatter('%(asctime)s [%(name)s:%(levelname)s] %(message)s')
+		fh.setFormatter(fmt)
+		logger.addHandler(fh)
+
+		# Run pipeline, raise exception on error, and close log file handler
+		try:
+			pipeline.run(file)
+		except Exception as e:
+			raise RuntimeError(
+				'Caugh exception during pipeline processing.'
+				'\nException: {}'.format(e)
+			)
+		finally:
+			logger.removeHandler(fh)
+			fh.close()
 
 	return
 

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -36,7 +36,7 @@ rad2mas = 180./np.pi*3600.*1000.
 # MAIN
 # =============================================================================
 
-def fourier_imshift(image, shift):
+def fourier_imshift(image, shift, pad=False, cval=0.0):
     """
     Fourier image shift. Adapted from JWST stage 3 pipeline.
     
@@ -46,7 +46,15 @@ def fourier_imshift(image, shift):
         A 2D/3D image to be shifted.
     shift : array
         xshift, yshift.
-    
+    pad : bool
+        Should we pad the array before shifting, then truncate?
+        Otherwise, the image is wrapped.
+    cval : sequence or float, optional
+        The values to set the padded values for each axis. Default is 0.
+        ((before_1, after_1), ... (before_N, after_N)) unique pad constants for each axis.
+        ((before, after),) yields same before and after constants for each axis.
+        (constant,) or int is a shortcut for before = after = constant for all axes.
+
     Returns
     -------
     offset : array
@@ -55,9 +63,25 @@ def fourier_imshift(image, shift):
     """
     
     if (image.ndim == 2):
+
+        ny, nx = image.shape
+
+        # Pad border with zeros
+        if pad:
+            xshift, yshift = shift
+            padx = np.abs(np.int(xshift)) + 5
+            pady = np.abs(np.int(yshift)) + 5
+            pad_vals = ([pady]*2,[padx]*2)
+            image = np.pad(image, pad_vals, 'constant', constant_values=cval)
+        else:
+            padx = pady = 0
+
         shift = np.asanyarray(shift)[:2]
         offset_image = fourier_shift(np.fft.fftn(image), shift[::-1])
         offset = np.fft.ifftn(offset_image).real
+
+        # Remove padded border to return to original size
+        offset = offset[pady:pady+ny, padx:padx+nx]
     
     elif (image.ndim == 3):
         nslices = image.shape[0]
@@ -67,10 +91,10 @@ def fourier_imshift(image, shift):
         
         offset = np.empty_like(image, dtype=float)
         for k in range(nslices):
-            offset[k] = fourier_imshift(image[k], shift[k])
+            offset[k] = fourier_imshift(image[k], shift[k], pad=pad, cval=cval)
     
     else:
-        raise ValueError('Input image must be either a 2D or a 3D array')
+        raise ValueError(f'Input image must be either a 2D or a 3D array. Found {image.ndim} dimensions.')
     
     return offset
 


### PR DESCRIPTION
Created a new JWST pipeline class called `Coron1Pipeline` (which is a subclass of `Detector1Pipeline`) into rampfit.py. This new class is called in place of `Detector1Pipeline`. It can act in the same way, but some pipeline defaults have been changed to better reflect possible improvements for coronagraphic data. As calibration files improve (e.g., higher SNR dark cals), the `Coron1Pipeline` can get modified. I’ve replaced the call to Detector1Pipeline with this class. 

New defaults include:
1. perform a pseudo-reference correction (number of top/bottom rows are set by a class attribute `nrow_ref`). Setting `nrow_ref=0` will disable this option. Default value is 20.
2. turn off diagonal growing for saturation pixels (still does horizontal/vertical crosses) using the attribute `grow_diagonal`.
3. ability to save all intermediate Stage 1 steps for monitoring / debugging using `save_intermediates` attribute.

Other minor changes:
- Writes all the logging info to a log file for future inspection. **TODO: Check for conflicts when running from command line.**  
- Add zero-padding to `utilsl.fourier_imshift` function to remove wrapping effects.
- Add a more extensive .gitignore