### PR TITLE
Adding ability to generate offsetpsf using from input spectrum

### DIFF
--- a/spaceKLIP/companion.py
+++ b/spaceKLIP/companion.py
@@ -167,9 +167,15 @@ def extract_companions(meta, recenter_offsetpsf=False, use_fm_psf=True,
                 else:
                     inst = 'NIRCAM'
                     immask = key.split('_')[-1]
-                    
+                if hasattr(meta, "psf_spec_file"):
+                    if meta.psf_spec_file != False:
+                        SED = io.read_spec_file(meta.psf_spec_file)
+                    else:
+                        SED = None
+                else:
+                    SED = None
                 offsetpsf_func = psf.JWST_PSF(inst, filt, immask, fov_pix=65,
-                                              sp=None, use_coeff=True,
+                                              sp=SED, use_coeff=True,
                                               date=meta.psfdate)
                 field_dep_corr = None #WebbPSF already corrects for transmissions. 
 

--- a/spaceKLIP/engine.py
+++ b/spaceKLIP/engine.py
@@ -131,7 +131,7 @@ class JWST(Pipeline):
         # Define the telescope and instrument properties.
         self.meta.diam = 6.5 # m; primary mirror diameter
         self.meta.iwa = 1. # pix; inner working angle
-        self.meta.owa = 150. # pix; outer working angle
+        self.meta.owa = 250. # pix; outer working angle
 
         # Define the ancillary directories.
         if (not os.path.isdir(self.meta.ancildir)):

--- a/tests/nircam_config.yaml
+++ b/tests/nircam_config.yaml
@@ -10,12 +10,12 @@
 
 ##### REQUIRED #####
 # Input Directory
-idir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/NIRCAM/F444W/'
-odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220801_NIRCAM/F444W/' # Output Directory
+idir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/NIRCAM/F300M/'
+odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220801_NIRCAM/F300M/' # Output Directory
 sdir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/HIP65426A_sdf_phoenix_m+modbb_disk_r.txt' #VOT table or stellar model file.
 
 ##### OPTIONAL #####
-rundirs: [] #'2022_08_02_ADI+RDI_annu1_subs1_run1', '2022_08_02_RDI_annu1_subs1_run1', '2022_08_02_ADI_annu1_subs1_run1']  #Specify directory(ies) within odir of existing runs to calculate contrast curve / companion
+rundirs: ['2022_08_02_RDI_annu1_subs1_run1'] #'2022_08_02_ADI+RDI_annu1_subs1_run1', '2022_08_02_RDI_annu1_subs1_run1', '2022_08_02_ADI_annu1_subs1_run1']  #Specify directory(ies) within odir of existing runs to calculate contrast curve / companion
 ancildir: None      # Specify directory to save ancillary files, if None then saved under odir/ANCILLARY/. 
 bg_sci_dir: None #'/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/MIRI/F1140C/BGSCI/' #None if not using
 bg_ref_dir: None #'/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/MIRI/F1140C/BGREF/' #None if not using
@@ -34,8 +34,8 @@ badpix_threshold: 1
 ##### Star / Companion information #####
 ########################################
 spt: 'A2V' # Spectral type of target, only necessary for VOTable
-ra_off: [410]  # mas; RA offset of the known companions
-de_off:  [-651] # mas; DEC offset of the known companions
+ra_off: [418]  # mas; RA offset of the known companions #-5300
+de_off:  [-697] # mas; DEC offset of the known companions #-6950
 starmagerrs: [0.054, 0] #Add 0 for NIRCam because of 335M
 
 #################################
@@ -108,21 +108,22 @@ pas_inject_bar: [45., 135., 225., 315.] # deg; list of position angles at which 
 comp_usefile: False # Either "bgsub" for background subtracted or False for regular
 repeatcentering_companion: False # False to not repeat, "basic" is not saved and must be repeated
 offpsf: 'webbpsf_ext'   #'webbpsf' for shifted offaxis, 'webbpsf_ext' for ~at location and time
+psf_spec_file: '/Users/acarter/Documents/DIRECT_IMAGING/JWST/ERS/HIP65426/hip65426b_bestfit_jansky.txt'
 psfdate: '2022-07-30T00:00:00'  #Input date for webbpsf_ext model
 
 nested: False
 mcmc: True
-nwalkers:  100   # For EMCEE photometry / astrometry fitting
+nwalkers:  50   # For EMCEE photometry / astrometry fitting
 nburn: 100
-nsteps: 200
-numthreads: 1
+nsteps: 50
+numthreads: 6
 
-x_range: 1. # pix
-y_range: 1. # pix
+x_range: 2. # pix
+y_range: 2. # pix
 flux_range: 10. # mag
 corr_len_range: 1.
-corr_len_guess: 1.
-fitboxsize: 30 # pix
+corr_len_guess: 1.8
+fitboxsize: 35 # pix
 fitkernel: 'matern32'
 dr: 5
 exc_rad: 3

--- a/tests/run_pipeline.py
+++ b/tests/run_pipeline.py
@@ -10,7 +10,7 @@ if __name__ == '__main__':
 	pipe.run_all(skip_ramp=True, 
 				 skip_imgproc=True, 
 				 skip_sub=True, 
-				 skip_rawcon=True, 
+				 skip_rawcon=False, 
 				 skip_calcon=True, 
 				 skip_comps=False)
 


### PR DESCRIPTION
Default generation of the offset psf is based off a 5700K blackbody, which can generate clear differences in the PSF compared to generating it from an input planetary spectrum. Now added the ability to generate offset psf's using a `psf_spec_file` attribute. File must be provided in micron, Jy 