### PR TITLE
Adding gaussian blurring

### DIFF
--- a/spaceKLIP/contrast.py
+++ b/spaceKLIP/contrast.py
@@ -680,6 +680,9 @@ def inject_recover(meta,
                     done += [i*Npa+j]
                     break
 
+    if not hasattr(meta, 'blur_images'):
+        meta.blur_images = False
+
     # If not finished yet, create a new pyKLIP dataset into which fake
     # companions will be injected.
     finished = False
@@ -688,7 +691,7 @@ def inject_recover(meta,
         dataset = JWST.JWSTData(filepaths=filepaths,
                                 psflib_filepaths=psflib_filepaths, centering=meta.centering_alg, badpix_threshold=meta.badpix_threshold,
                                 scishiftfile=meta.ancildir+'shifts/scishifts', refshiftfile=meta.ancildir+'shifts/refshifts',
-                                fiducial_point_override=meta.fiducial_point_override)
+                                fiducial_point_override=meta.fiducial_point_override, blur=meta.blur_images)
 
         # Inject fake companions. Make sure that no other fake companion
         # closer than mrad will be injected into the same dataset.

--- a/spaceKLIP/psf.py
+++ b/spaceKLIP/psf.py
@@ -101,9 +101,9 @@ class JWST_PSF():
             func_on = inst_on.calc_psf
             func_off = inst_off.calc_psf
             inst_on.options['jitter'] = 'gaussian'
-            inst_on.options['jitter_sigma'] = 0.003
+            inst_on.options['jitter_sigma'] = 0.00#3
             inst_off.options['jitter'] = 'gaussian'
-            inst_off.options['jitter_sigma'] = 0.003
+            inst_off.options['jitter_sigma'] = 0.00#3
 
         # Renormalize spectrum to have 1 e-/sec within bandpass to obtain normalized PSFs
         if sp is not None:

--- a/spaceKLIP/subtraction.py
+++ b/spaceKLIP/subtraction.py
@@ -415,6 +415,9 @@ def klip_subtraction(meta, files):
                 if not os.path.exists(meta.ancildir+'shifts'):
                     os.makedirs(meta.ancildir+'shifts')
 
+                if not hasattr(meta, 'blur_images'):
+                    meta.blur_images = False
+
                 # Loop through all sets of observing parameters. Only run
                 # pyKLIP if the corresponding KLmodes-all fits file does
                 # not exist yet.
@@ -429,7 +432,7 @@ def klip_subtraction(meta, files):
                     dataset = JWST.JWSTData(filepaths=filepaths,
                                             psflib_filepaths=psflib_filepaths, centering=meta.centering_alg, badpix_threshold=meta.badpix_threshold,
                                             scishiftfile=meta.ancildir+'shifts/scishifts', refshiftfile=meta.ancildir+'shifts/refshifts',
-                                            fiducial_point_override=meta.fiducial_point_override)
+                                            fiducial_point_override=meta.fiducial_point_override, blur=meta.blur_images)
                     
                     #Set an OWA if it exists. 
                     if hasattr(meta, 'OWA'): dataset.OWA = meta.OWA
@@ -449,7 +452,7 @@ def klip_subtraction(meta, files):
                                               psf_library=dataset.psflib,
                                               highpass=False,
                                               verbose=meta.verbose,
-                                              algo=meta.algorithm)
+                                              algo=algo)
 
                 # Save a meta file under each directory
                 smeta = copy.deepcopy(meta)

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -461,7 +461,7 @@ def field_dependent_correction(stamp,
     # peak_index = np.unravel_index(stamp.argmax(), stamp.shape)
     # transmission_at_center =  transmission[peak_index[1],peak_index[0]]
 
-    return transmission_at_center*stamp
+    return transmission*stamp
 
 def get_stellar_magnitudes(meta):
     # First find out if a file was provided correctly

--- a/tests/miri_config.yaml
+++ b/tests/miri_config.yaml
@@ -15,10 +15,10 @@ odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220801_F1
 sdir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/HIP65426A_sdf_phoenix_m+modbb_disk_r.txt' #VOT table or stellar model file.
 
 ##### OPTIONAL #####
-rundirs: ['2022_08_01_ADI_annu1_subs1_run1', '2022_08_01_RDI_annu1_subs1_run1', 2022_08_01_ADI+RDI_annu1_subs1_run1]  #Specify directory(ies) within odir of existing runs to calculate contrast curve / companion
+rundirs: ['2022_08_01_ADI+RDI_annu1_subs1_run1']  #Specify directory(ies) within odir of existing runs to calculate contrast curve / companion
 ancildir: None      # Specify directory to save ancillary files, if None then saved under odir/ANCILLARY/. 
 bg_sci_dir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/MIRI/F1550C/BGSCI/' #None if not using
-bg_ref_dir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/MIRI/F1550C/BGREF/' #None if not using
+bg_ref_dir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/MIRI/F1150C/BGREF/' #None if not using
 
 ############################
 ##### General Settings #####
@@ -34,9 +34,9 @@ badpix_threshold: 1
 ##### Star / Companion information #####
 ########################################
 spt: 'A2V' # Spectral type of target, only necessary for VOTable
-starmagerrs: [0.072] #[0.038]
-ra_off: [558]  # mas; RA offset of the known companions
-de_off:  [-651] # mas; DEC offset of the known companions
+starmagerrs: [0.038] #[0.072]
+ra_off: [418]  # mas; RA offset of the known companions
+de_off:  [-696] # mas; DEC offset of the known companions
 
 #################################
 ##### Ramp Fitting Settings #####
@@ -69,7 +69,7 @@ use_cleaned: True   #Use files generated after (True) or before (False) outlier 
 bgtrim: 'first'  # Trim the first integration in the background, science, and reference (bgsub != 'saved' or 'None')
 bgsub: 'default'    #Perform background subtraction, 'default' for median, 'pyklip' for klip, 'leastsq' for loci
 bgmed_splits: [12,4]   #12,4  #Peform median background subtraction but split across [Nsci,Nref] ~equal different sections
-bgonly: False     # Only perform the background subtraction
+bgonly: False    # Only perform the background subtraction
 centering_alg: 'basic'    # Algorithm to use for centering "basic", "jwstpipe", "imageregis", or 'savefile'
 mode: ['ADI+RDI', 'ADI', 'RDI']       # list of modes for pyKLIP, will loop through all
 annuli: [1]         # list of number of annuli for pyKLIP, will loop through all
@@ -82,7 +82,7 @@ numbasis: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,30,40,50] # list o
 conc_usefile: 'bgsub' # Either "bgsub" for background subtracted or False for regular
 fwhm_scale: 1.5      #Scale to mask companions with
 repeatcentering_contrast: 'basic' # False to not repeat, "basic" is not saved and must be repeated
-KL: 15 # Number of KL components for which the calibrated contrast curve and the companion properties shall be computed (must be in subtracted numbasis)
+KL: 10 # Number of KL components for which the calibrated contrast curve and the companion properties shall be computed (must be in subtracted numbasis)
 
 # TODO: MASK LOCATIONS
 
@@ -102,21 +102,22 @@ pas_inject_bar: [45., 135., 225., 315.] # deg; list of position angles at which 
 comp_usefile: 'bgsub'  # Either "bgsub" for background subtracted or False for regular
 repeatcentering_companion: 'basic' # False to not repeat, "basic" is not saved and must be repeated
 offpsf: 'webbpsf_ext'   #'webbpsf' for shifted offaxis, 'webbpsf_ext' for ~at location and time
+psf_spec_file: '/Users/acarter/Documents/DIRECT_IMAGING/JWST/ERS/HIP65426/hip65426b_bestfit_jansky.txt'
 psfdate: '2022-07-18T00:00:00'  #Input date for webbpsf_ext model
 
 nested: False
 mcmc: True
-nwalkers:  100   # For EMCEE photometry / astrometry fitting
+nwalkers: 50   # For EMCEE photometry / astrometry fitting
 nburn: 100
 nsteps: 200
-numthreads: 6
+numthreads: 4
 
 x_range: 3. # pix
 y_range: 3. # pix
 flux_range: 10. # mag
 corr_len_range: 1.
 corr_len_guess: 3.
-fitboxsize: 25 # pix
+fitboxsize: 30 # pix
 fitkernel: 'diag'
 dr: 5
 exc_rad: 3

--- a/tests/nircam_config.yaml
+++ b/tests/nircam_config.yaml
@@ -10,12 +10,12 @@
 
 ##### REQUIRED #####
 # Input Directory
-idir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/NIRCAM/F300M/'
-odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220801_NIRCAM/F300M/' # Output Directory
+idir: '/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/NIRCAM/F250M/'
+odir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/20220805_NIRCAM/F250M/' # Output Directory
 sdir: '/Users/acarter/Documents/DIRECT_IMAGING/CORONAGRAPHY_PIPELINE/HIP65426A_sdf_phoenix_m+modbb_disk_r.txt' #VOT table or stellar model file.
 
 ##### OPTIONAL #####
-rundirs: ['2022_08_02_RDI_annu1_subs1_run1'] #'2022_08_02_ADI+RDI_annu1_subs1_run1', '2022_08_02_RDI_annu1_subs1_run1', '2022_08_02_ADI_annu1_subs1_run1']  #Specify directory(ies) within odir of existing runs to calculate contrast curve / companion
+rundirs: [] #'2022_08_02_ADI+RDI_annu1_subs1_run1', '2022_08_02_RDI_annu1_subs1_run1', '2022_08_02_ADI_annu1_subs1_run1']  #Specify directory(ies) within odir of existing runs to calculate contrast curve / companion
 ancildir: None      # Specify directory to save ancillary files, if None then saved under odir/ANCILLARY/. 
 bg_sci_dir: None #'/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/MIRI/F1140C/BGSCI/' #None if not using
 bg_ref_dir: None #'/Users/acarter/Documents/DIRECT_IMAGING/DATA/ERS1386/HIP65426/MIRI/F1140C/BGREF/' #None if not using
@@ -34,9 +34,9 @@ badpix_threshold: 1
 ##### Star / Companion information #####
 ########################################
 spt: 'A2V' # Spectral type of target, only necessary for VOTable
-ra_off: [418]  # mas; RA offset of the known companions #-5300
-de_off:  [-697] # mas; DEC offset of the known companions #-6950
-starmagerrs: [0.054, 0] #Add 0 for NIRCam because of 335M
+ra_off: [418] # [-5300] #mas; RA offset of the known companions
+de_off:  [-696] #[-6950] #mas; DEC offset of the known companions 
+starmagerrs: [0.054, 0] #Add 0 for NIRCam because of 335M [F210M: 0.054, F300M: 0.046, F356M: 0.048, F410M: 0.051, F444M: 0.054, F1140C: 0.038, F1550C:: 0.072]
 
 #################################
 ##### Ramp Fitting Settings #####
@@ -76,8 +76,9 @@ bgtrim: 0  # Trim the first integration in the background, science, and referenc
 bgsub: 'None'    #Perform background subtraction, 'default' for median, 'pyklip' for klip, 'leastsq' for loci
 bgmed_splits: [8,2]   #12,4  #Peform median background subtraction but split across [Nsci,Nref] ~equal different sections
 bgonly: False     # Only perform the background subtraction
+blur_images: 1
 centering_alg: 'jwstpipe'    # Algorithm to use for centering "basic", "jwstpipe", "imageregis", or 'savefile'
-mode: ['ADI', 'RDI', 'ADI+RDI']       # list of modes for pyKLIP, will loop through all
+mode: ['ADI+RDI']       # list of modes for pyKLIP, will loop through all
 annuli: [1]         # list of number of annuli for pyKLIP, will loop through all
 subsections: [1]    # list of number of annuli for pyKLIP, will loop through all
 numbasis: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,30,40,50] # list of number of basis vectors for pyKLIP, will loop through all
@@ -88,7 +89,7 @@ numbasis: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,30,40,50] # list o
 conc_usefile: False # Either "bgsub" for background subtracted or False for regular
 fwhm_scale: 10      #Scale to mask companions with
 repeatcentering_contrast: False # False to not repeat, "basic" is not saved and must be repeated
-KL: 5 # Number of KL components for which the calibrated contrast curve and the companion properties shall be computed (must be in subtracted numbasis)
+KL: 10 # Number of KL components for which the calibrated contrast curve and the companion properties shall be computed (must be in subtracted numbasis)
 
 # TODO: MASK LOCATIONS
 
@@ -113,17 +114,17 @@ psfdate: '2022-07-30T00:00:00'  #Input date for webbpsf_ext model
 
 nested: False
 mcmc: True
-nwalkers:  50   # For EMCEE photometry / astrometry fitting
+nwalkers: 50   # For EMCEE photometry / astrometry fitting
 nburn: 100
-nsteps: 50
-numthreads: 6
+nsteps: 200
+numthreads: 4
 
-x_range: 2. # pix
-y_range: 2. # pix
+x_range: 1. # pix
+y_range: 1. # pix
 flux_range: 10. # mag
 corr_len_range: 1.
-corr_len_guess: 1.8
-fitboxsize: 35 # pix
-fitkernel: 'matern32'
+corr_len_guess: 1.
+fitboxsize: 30 # pix
+fitkernel: 'diag'
 dr: 5
 exc_rad: 3

--- a/tests/run_pipeline.py
+++ b/tests/run_pipeline.py
@@ -9,8 +9,8 @@ if __name__ == '__main__':
 	pipe = JWST(config_file)
 	pipe.run_all(skip_ramp=True, 
 				 skip_imgproc=True, 
-				 skip_sub=True, 
-				 skip_rawcon=False, 
+				 skip_sub=False, 
+				 skip_rawcon=True, 
 				 skip_calcon=True, 
 				 skip_comps=False)
 


### PR DESCRIPTION
Small update (must have updated pyKLIP to the latest jwst branch too) that allows you to perform some Gaussian blurring to the input images for PSF subtraction, and companion injection/fitting. 

All done through the `blur_images` attribute in the config file. Future development could be to only use the blurring for specific things. Helps a lot with Fourier artifacts in the F250M data. 