### PR TITLE
Dev/mdp: add docs overview page, and add support for environment variables in paths

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,11 +3,16 @@
 .. Welcome to ``spaceKLIP``'s documentation
 .. ========================================
 
+Documentation for spaceKLIP
+===========================
+
 .. image:: _static/logo.png
    :align: center
    :width: 400px
 
-spaceKLIP is a data reduction pipeline for JWST high contrast imaging. All code is currently under heavy development
+spaceKLIP is a data reduction pipeline for JWST high contrast imaging. 
+
+All code is currently under heavy development
 and typically expected features may not be available. 
 
 Compatible Simulated Data: `Here <https://stsci.box.com/s/cktghuyrwrallb401rw5y5da2g5ije6t>`_
@@ -27,6 +32,7 @@ Compatible Simulated Data: `Here <https://stsci.box.com/s/cktghuyrwrallb401rw5y5
    :hidden:
 
    tutos
+   tutorials/Introduction.ipynb
    tutorials/01_quickstart.ipynb
 
 .. toctree::

--- a/docs/source/tutorials/Introduction.ipynb
+++ b/docs/source/tutorials/Introduction.ipynb
@@ -1,0 +1,117 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "eed5960c",
+   "metadata": {},
+   "source": [
+    "# Introduction to spaceKLIP\n",
+    "\n",
+    "\n",
+    "## Basic Concepts\n",
+    "\n",
+    "spaceKLIP supports all stages of reduction of JWST coronagraphic data, from raw ramps to PSF-subtracted images to calibrated photometry and contrast curves. It does this via subclassing and extending the JWST pipeline.\n",
+    "\n",
+    "In particular spaceKLIP will help to:\n",
+    "1. Perform ramp fitting (pipeline stage 1) with settings optimized for coronagraphic data with NIRCam and MIRI\n",
+    "2. Process your images to register references and science data together, clean bad pixels, and so on. \n",
+    "3. Perform PSF subtraction using RDI or ADI for diversity, and using the KLIP or NMF algorithms. \n",
+    "4. Perform calibrated photometric and astrometric measurements on coronagraphic data. \n",
+    "5. Conduct forward modeling to understand systematics, or inject sources to measure achieved contrast levels, and other such supporting calculations. \n",
+    "\n",
+    "### Organizing your data\n",
+    "\n",
+    "spaceKLIP expects to work with files organized with particular directory structure, to help organize the outputs of each stage of processing. This includes having multiple output subdirectories for different PSF subtraction runs (e.g. trying different PSF subtraction methods or parameters to optimize subtraction performance.)\n",
+    "\n",
+    "Here's an example of typical directory structure:\n",
+    "\n",
+    "\n",
+    "```\n",
+    "SOME_TARGET_NAME\n",
+    "└── F300M_MASK335R\n",
+    "  ├── RAMPFIT\n",
+    "  │  └── SCI+REF\n",
+    "  ├── IMGPROCESS\n",
+    "  │  ├── SCI+REF\n",
+    "  │  └── SCI+REF_CLEAN\n",
+    "  ├── ANCILLARY\n",
+    "  │  └── shifts\n",
+    "  ├── 2022_08_10_ADI_annu1_subs1_run1\n",
+    "  │  └── SUBTRACTED\n",
+    "  ├── 2022_08_10_ADI+RDI_annu1_subs1_run1\n",
+    "  │  └── SUBTRACTED\n",
+    "  ├── 2022_08_10_RDI_annu1_subs1_run1\n",
+    "  │  └── SUBTRACTED\n",
+    "  ├── 2022_08_11_ADI+RDI_annu1_subs1_run1\n",
+    "  │  └── SUBTRACTED\n",
+    "  └── 2022_08_11_ADI+RDI_annu1_subs1_run2\n",
+    "     └── SUBTRACTED\n",
+    "```\n",
+    "That pattern could be repeated multiple times for additonal filters or other coronagraph masks, etc. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f341158",
+   "metadata": {},
+   "source": [
+    "## Understanding spaceKLIP Config Files\n",
+    "\n",
+    "SpaceKLIP makes heavy use of configuration files to define inputs and parameters. These are text files using YAML syntax.\n",
+    "\n",
+    "The config files are complicated and have many settings. For now, it's best to start from an existing config file and modify as needed for other datasets. There may eventually be utility functions to automatically generate configuration files, but not yet.\n",
+    "\n",
+    "Configuration settings are <a href='https://spaceklip.readthedocs.io/en/latest/Config_file.html'>partially documented here</a>.\n",
+    "\n",
+    "\n",
+    "#### Configuration files are per each observation mode, including filter + occulter.\n",
+    "\n",
+    "Currently, it's necessary to have a separate config file per each unique coronagraph dataset (including choice of occulter and filter). For instance, if you have a target observed with NIRCam MASK335R in 3 different filters, you will need 3 different config files, one per filter. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "464db525",
+   "metadata": {},
+   "source": [
+    "#### Specifying Paths in Config Files\n",
+    "\n",
+    "Config files need to include paths to the data files to reduce. You may do this with full absolute paths or relative path. \n",
+    "\n",
+    "To help enable portable use of config files shared between users or on different computers, paths can be specified using environment variables, or using `~` to refer to the home directory. \n",
+    "\n",
+    "It is recommended, but not required, to define an environment variable `$SPACEKLIP_DATA_PATH` and set this to the directory under which you would like to organize your data. Doing this, plus organizing your data as recommended above, will help to allow sharing config files between users for reproducible science. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "291e267a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/spaceKLIP/engine.py
+++ b/spaceKLIP/engine.py
@@ -78,6 +78,12 @@ class Pipeline():
         for key in config:
             setattr(self.meta, key, config[key])
 
+        # For required path parameters, expand any environment variables or ~ for user home directory
+        for key in ['idir', 'odir', 'sdir']:
+            setattr(self.meta, key, io.expand_path(getattr(self.meta, key)))
+        if hasattr(self.meta, 'data_dir'):
+            setattr(self.meta, 'data_dir', io.expand_path(getattr(self.meta, 'data_dir')))
+
         # Assign run directories from output folder. These will be overwritten if subtraction if performed.
         if (self.meta.rundirs != None) or (len(self.meta.rundirs) == 0):
             if len(self.meta.rundirs) == 0:
@@ -91,7 +97,7 @@ class Pipeline():
 
 class JWST(Pipeline):
     """
-    JWST-specifc pipeline class.
+    JWST-specific pipeline class.
 
     """
 

--- a/spaceKLIP/engine.py
+++ b/spaceKLIP/engine.py
@@ -129,7 +129,7 @@ class JWST(Pipeline):
 
         return None
 
-    def sort_files(self):
+    def sort_files(self, **kwargs):
         """Sort files into subdirectories like filter_mask (e.g., F300M_MASK335R)"""
 
         idir = self.meta.idir[:-1] if self.meta.idir[-1]=='/' else self.meta.idir
@@ -148,7 +148,7 @@ class JWST(Pipeline):
 
         io.sort_data_files(self.meta.pid, self.meta.sci_obs, self.meta.ref_obs, outdir, 
                            indir=indir, expid_sci=self.meta.expid_sci, 
-                           filter=filter, coron_mask=coron_mask)
+                           filter=filter, coron_mask=coron_mask, **kwargs)
 
     def get_jwst_meta(self):
         """

--- a/spaceKLIP/io.py
+++ b/spaceKLIP/io.py
@@ -592,3 +592,14 @@ def close_log_file(logger, file_handler):
 
     logger.removeHandler(file_handler)
     file_handler.close()
+
+def expand_path(path_string):
+    """Expand environment variables or user home directories in a path specification
+
+    Parameters
+    ==========
+    path_string : str
+        Any path string, relative or absolute, optionally containing environment variables.
+
+    """
+    return os.path.expanduser(os.path.expandvars(path_string))


### PR DESCRIPTION
A couple semi-related additions: 

- Adds a new docs page with a (partial) big picture introduction to some of the concepts and how files are organized. This is just a starting point of course
- Adds support for environment variables in paths
- As part of not-yet-complete work to update the 01_quickstart notebook using the simulated data, add some flexibility to the sort_files function to help it work on the simulated data. Also add more verbose outputs for debugging, optionally. 