### PR TITLE
Automatic identification of reference target

### DIFF
--- a/spaceKLIP/engine.py
+++ b/spaceKLIP/engine.py
@@ -124,6 +124,7 @@ class JWST(Pipeline):
 
         # Get the JWST-specific metadata.
         self.get_jwst_meta()
+        self.meta_checks()
 
         return None
 
@@ -147,33 +148,6 @@ class JWST(Pipeline):
         io.sort_data_files(self.meta.pid, self.meta.sci_obs, self.meta.ref_obs, outdir, 
                            indir=indir, expid_sci=self.meta.expid_sci, 
                            filter=filter, coron_mask=coron_mask)
-
-    def meta_checks(self):
-        """Check some consistencies in the meta file"""
-
-        meta = self.meta
-
-        # Check if outlier correction / cleaning requested
-        if hasattr(meta, 'outlier_corr') and ((meta.outlier_corr is not None) or (meta.outlier_corr.lower() != 'none')):
-            outlier_type = meta.outlier_corr
-        else:
-            outlier_type = None
-
-        # Was cleaning requested on existing cal data?
-        do_clean_only = do_clean = False
-        if hasattr(meta, 'outlier_only') and meta.outlier_only:
-            do_clean_only = True
-            do_clean = True  # Must be set to True
-            if outlier_type is None:
-                log.warning('Meta: outlier_only=True but outlier_corr not specified.')
-        if outlier_type is not None:
-            do_clean = True
-
-        if hasattr(meta, 'use_cleaned'):
-            if meta.used_clean and not do_clean:
-                log.warning('Meta: use_cleaned=True for KLIP subtraction, but no cleaning options specified.')
-            if not meta.used_clean and do_clean:
-                log.warning('Meta: Image cleaning will be performed, but use_cleaned=False for KLIP subtraction.')
 
     def get_jwst_meta(self):
         """
@@ -274,6 +248,33 @@ class JWST(Pipeline):
         sign = np.sign(self.siaf.apertures[refapername].V2Ref-self.siaf.apertures[apername].V2Ref)
 
         return sign*offset_arcsec
+
+    def meta_checks(self):
+        """Check some consistencies in the meta file"""
+
+        meta = self.meta
+
+        # Check if outlier correction / cleaning requested
+        if hasattr(meta, 'outlier_corr') and ((meta.outlier_corr is not None) or (meta.outlier_corr.lower() != 'none')):
+            outlier_type = meta.outlier_corr
+        else:
+            outlier_type = None
+
+        # Was cleaning requested on existing cal data?
+        do_clean_only = do_clean = False
+        if hasattr(meta, 'outlier_only') and meta.outlier_only:
+            do_clean_only = True
+            do_clean = True  # Must be set to True
+            if outlier_type is None:
+                log.warning('Meta: outlier_only=True but outlier_corr not specified.')
+        if outlier_type is not None:
+            do_clean = True
+
+        if hasattr(meta, 'use_cleaned'):
+            if meta.used_clean and not do_clean:
+                log.warning('Meta: use_cleaned=True for KLIP subtraction, but no cleaning options specified.')
+            if not meta.used_clean and do_clean:
+                log.warning('Meta: Image cleaning will be performed, but use_cleaned=False for KLIP subtraction.')
 
     def run_all(self, skip_ramp=False, skip_imgproc=False, skip_sub=False,
                 skip_rawcon=False, skip_calcon=False, skip_comps=False):

--- a/spaceKLIP/engine.py
+++ b/spaceKLIP/engine.py
@@ -271,9 +271,9 @@ class JWST(Pipeline):
             do_clean = True
 
         if hasattr(meta, 'use_cleaned'):
-            if meta.used_clean and not do_clean:
+            if meta.use_cleaned and not do_clean:
                 log.warning('Meta: use_cleaned=True for KLIP subtraction, but no cleaning options specified.')
-            if not meta.used_clean and do_clean:
+            if not meta.use_cleaned and do_clean:
                 log.warning('Meta: Image cleaning will be performed, but use_cleaned=False for KLIP subtraction.')
 
     def run_all(self, skip_ramp=False, skip_imgproc=False, skip_sub=False,

--- a/spaceKLIP/io.py
+++ b/spaceKLIP/io.py
@@ -225,35 +225,20 @@ def extract_obs(meta, fitsfiles_all):
         # elif ('HD141569' in file): # MIRI test data
         #     SUBPXPTS[i] = 1
         # else:
-        try:
-            SUBPXPTS[i] = head['NUMDTHPT']
-        except:
-            SUBPXPTS[i] = 1
-        try:
-            SUBPXPTS[i] = head['NUMDTHPT']
-        except:
-            SUBPXPTS[i] = 1
-        try: # Check for ISPSF header keyword
-            ISPSF[i] = head['ISPSF']
-        except:
-            ISPSF[i] = 'NONE'
-        try: # Check for SELFREF header keyword
-            SELFREF[i] = head['SELFREF']
-        except:
-            SELFREF[i] = 'NONE'
-        try:
-            APERNAME[i] = head['APERNAME']
-        except:
-            APERNAME[i] = 'NONE'
+        SUBPXPTS[i] = head.get('NUMDTHPT', 1)
+        # Check for ISPSF and SELFREF header keywords
+        ISPSF[i] = head.get('ISPSF', 'NONE') 
+        SELFREF[i] = head.get('SELFREF', 'NONE')
+        APERNAME[i] = head.get('APERNAME', 'NONE')
         if (INSTRUME[i] == 'NIRCAM'):
-            if ('LONG' in DETECTOR[i]):
+            if ('LONG' in DETECTOR[i] or '5' in DETECTOR[i]):
                 PIXSCALE[i] = nrc._pixelscale_long*1e3 # mas
             else:
                 PIXSCALE[i] = nrc._pixelscale_short*1e3 # mas
         elif (INSTRUME[i] == 'MIRI'):
             PIXSCALE[i] = mir.pixelscale*1e3 # mas
         else:
-            raise UserWarning('Unknown instrument')
+            raise UserWarning(f'Unknown instrument: {INSTRUME[i]}. Must be either NIRCAM or MIRI.')
 
         # Science header
         head = hdul['SCI'].header
@@ -293,7 +278,7 @@ def extract_obs(meta, fitsfiles_all):
     meta.pixar_sr = {}
     meta.obs = {}
 
-    print(SUBPXPTS)
+    # print(SUBPXPTS)
     for i in range(NHASH_unique):
         ww = HASH == HASH_unique[i]
 

--- a/spaceKLIP/rampfit.py
+++ b/spaceKLIP/rampfit.py
@@ -350,8 +350,9 @@ def run_ramp_fitting(meta, idir, osubdir):
         if hasattr(meta, 'grow_diagonal'):
             pipeline.nrow_ref = meta.grow_diagonal
         if hasattr(meta, 'sat_boundary'):
-            pipeline.saturation.n_pix_grow_sat
-
+            pipeline.saturation.n_pix_grow_sat = meta.sat_boundary
+        if hasattr(meta, 'weighting'):
+            pipeline.ramp_fit.weighting = meta.weighting
 
         # Run pipeline, raise exception on error, and close log file handler
         try:


### PR DESCRIPTION
Previously, references were identified by the presence of small grid dithers. However, some science observations will have SGDs defined. In addition, there is an ISPSF header keyword used to identify if an observation is a reference target. I have updated the code to first look for the ISPSF header keyword and flag observations as either science or reference based on this header value. However, most simulated data do not have this keyword, so if not found, spaceKLIP will fall back to the previous method of looking for multiple dither positions to identify reference targets.