### PR TITLE
add MAST query tool for coronagraphy datasets

### DIFF
--- a/docs/source/tutorials/MAST query tools for coronagraphic datasets.ipynb
+++ b/docs/source/tutorials/MAST query tools for coronagraphic datasets.ipynb
@@ -1,0 +1,286 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e0e954ad",
+   "metadata": {},
+   "source": [
+    "# MAST query tools for coronagraphic datasets\n",
+    "\n",
+    "SpaceKLIP includes some simple query tools for searching available coronagraphic datasets in MAST. \n",
+    "\n",
+    "These are intended for, for instance, determining if there are PSF or background observations from other programs\n",
+    "that may be useful in reducing a given science dataset. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1f8be17",
+   "metadata": {},
+   "source": [
+    "Let's see what's available for NIRCam F356W. This returns a table of all observations, including science obs, PSF reference obs, and background obs (for MIRI). \n",
+    "\n",
+    "This output is a bit long; We'll show next how to filter that to particular kinds of data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "42af02a4",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table length=34</i>\n",
+       "<table id=\"table140685167378144\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>visit_id</th><th>start time</th><th>filter</th><th>kind</th><th>coronmsk</th><th>targname</th><th>obslabel</th><th>duration</th><th>numdthpt</th><th>program</th><th>title</th><th>pi_name</th></tr></thead>\n",
+       "<thead><tr><th>str12</th><th>str16</th><th>str5</th><th>bytes3</th><th>str9</th><th>str22</th><th>str54</th><th>float64</th><th>int64</th><th>int64</th><th>str75</th><th>str20</th></tr></thead>\n",
+       "<tr><td>V01386001001</td><td>2022-07-29 22:01</td><td>F356W</td><td>REF</td><td>MASKA335R</td><td>* phi Cen</td><td>NIRCam 335R - REF</td><td>83.426</td><td>9</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386002001</td><td>2022-07-30 01:13</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>HD 116434</td><td>NIRCam 335R - Roll 1</td><td>617.946</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386003001</td><td>2022-07-30 03:16</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>HD 116434</td><td>NIRCam 335R - Roll 2</td><td>617.946</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01184015001</td><td>2022-09-06 00:00</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>LP 944-20</td><td>LP 944-20 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184016001</td><td>2022-09-06 01:43</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>LP 944-20</td><td>LP 944-20 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184017001</td><td>2022-09-06 03:19</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>2MASSI J0443376+000205</td><td>2MJ0443 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184018001</td><td>2022-09-06 05:02</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>2MASSI J0443376+000205</td><td>2MJ0443 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184001001</td><td>2022-10-03 04:37</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>V* AU Mic</td><td>AU Mic roll 1</td><td>872.685</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184002001</td><td>2022-10-03 08:34</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>V* AU Mic</td><td>AU Mic roll 2</td><td>872.685</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184003001</td><td>2022-10-03 10:03</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G 80-21</td><td>HIP17695 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184004001</td><td>2022-10-03 12:08</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G 80-21</td><td>HIP17695 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184005001</td><td>2022-10-03 13:36</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G-7-34</td><td>G 7-34 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184006001</td><td>2022-10-03 15:37</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G-7-34</td><td>G 7-34 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184008001</td><td>2022-10-03 19:02</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>LP 776-25</td><td>TYC5899 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01412001001</td><td>2022-10-19 19:41</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* c Eri</td><td>51 Eri - NIRCam - Roll 1 - MASK430R</td><td>630.299</td><td>1</td><td>1412</td><td>Characterizing 51 Eridani Exoplanetary System</td><td>Perrin, Marshall</td></tr>\n",
+       "<tr><td>V01412003001</td><td>2022-10-19 23:20</td><td>F356W</td><td>REF</td><td>MASKA430R</td><td>HD 30562</td><td>Ref star - NIRCam - MASK430R</td><td>231.158</td><td>5</td><td>1412</td><td>Characterizing 51 Eridani Exoplanetary System</td><td>Perrin, Marshall</td></tr>\n",
+       "<tr><td>V01412006001</td><td>2022-10-20 06:12</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* c Eri</td><td>51 Eri - NIRCam - Roll 2 - MASK430R</td><td>630.299</td><td>1</td><td>1412</td><td>Characterizing 51 Eridani Exoplanetary System</td><td>Perrin, Marshall</td></tr>\n",
+       "<tr><td>V01193014001</td><td>2022-10-22 06:13</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* alf PsA</td><td>Fomalhaut - NIRCam - Roll 1 - FULL - MA430R</td><td>407.997</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01193015001</td><td>2022-10-22 07:12</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* alf PsA</td><td>Fomalhaut - NIRCam - Roll 1 - SUB320 - MA430R</td><td>451.147</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01193016001</td><td>2022-10-22 07:58</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* alf PsA</td><td>Fomalhaut - NIRCam - Roll 2 - SUB320 - M430R</td><td>451.147</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01193017001</td><td>2022-10-22 09:09</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* alf PsA</td><td>Fomalhaut - NIRCam - Roll 2 - FULL - M430R</td><td>407.997</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01193018001</td><td>2022-10-22 09:46</td><td>F356W</td><td>REF</td><td>MASKA430R</td><td>* del Aqr</td><td>Fomalhaut Ref star - NIRCam - Roll 2 - SUB320 - MA430R</td><td>182.085</td><td>5</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01193019001</td><td>2022-10-22 11:16</td><td>F356W</td><td>REF</td><td>MASKA430R</td><td>* del Aqr</td><td>Fomalhaut Ref star - NIRCam - Roll 2 - FULL - MA430R</td><td>150.315</td><td>5</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01184009001</td><td>2022-11-26 15:52</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>FOMALHAUT-C</td><td>Fomalhaut C roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184010001</td><td>2022-11-26 21:09</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>FOMALHAUT-C</td><td>Fomalhaut C roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184011001</td><td>2022-11-26 22:34</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>V* AP Col</td><td>AP Col roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184012001</td><td>2022-11-27 00:54</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>V* AP Col</td><td>AP Col roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184013001</td><td>2022-11-27 02:19</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G 161-71</td><td>2MJ0944 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184014001</td><td>2022-11-27 04:18</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G 161-71</td><td>2MJ0944 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01194001001</td><td>2022-11-27 17:40</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>HR8799</td><td>HR 8799 - NIRCam - Roll 1 - MASK335R</td><td>454.854</td><td>1</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01194003001</td><td>2022-11-27 19:08</td><td>F356W</td><td>REF</td><td>MASKA335R</td><td>* ups Peg\\`</td><td>Ref star - NIRCam - MASK335R</td><td>72.777</td><td>5</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01194006001</td><td>2022-11-27 21:03</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>HR8799</td><td>HR 8799 - NIRCam - Roll 2 - MASK335R</td><td>454.854</td><td>1</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01184027001</td><td>2023-02-11 14:45</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>LP 776-25</td><td>TYC5899 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184028001</td><td>2023-02-22 18:16</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>LP 776-25</td><td>TYC5899 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table length=34>\n",
+       "  visit_id      start time    filter  kind   coronmsk        targname        ... duration numdthpt program                                    title                                          pi_name       \n",
+       "   str12          str16        str5  bytes3    str9           str22          ... float64   int64    int64                                     str75                                           str20        \n",
+       "------------ ---------------- ------ ------ --------- ---------------------- ... -------- -------- ------- --------------------------------------------------------------------------- --------------------\n",
+       "V01386001001 2022-07-29 22:01  F356W    REF MASKA335R              * phi Cen ...   83.426        9    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
+       "V01386002001 2022-07-30 01:13  F356W    SCI MASKA335R              HD 116434 ...  617.946        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
+       "V01386003001 2022-07-30 03:16  F356W    SCI MASKA335R              HD 116434 ...  617.946        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
+       "V01184015001 2022-09-06 00:00  F356W    SCI MASKA335R              LP 944-20 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184016001 2022-09-06 01:43  F356W    SCI MASKA335R              LP 944-20 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184017001 2022-09-06 03:19  F356W    SCI MASKA335R 2MASSI J0443376+000205 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184018001 2022-09-06 05:02  F356W    SCI MASKA335R 2MASSI J0443376+000205 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184001001 2022-10-03 04:37  F356W    SCI MASKA335R              V* AU Mic ...  872.685        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184002001 2022-10-03 08:34  F356W    SCI MASKA335R              V* AU Mic ...  872.685        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184003001 2022-10-03 10:03  F356W    SCI MASKA335R                G 80-21 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184004001 2022-10-03 12:08  F356W    SCI MASKA335R                G 80-21 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184005001 2022-10-03 13:36  F356W    SCI MASKA335R                 G-7-34 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184006001 2022-10-03 15:37  F356W    SCI MASKA335R                 G-7-34 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184008001 2022-10-03 19:02  F356W    SCI MASKA335R              LP 776-25 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01412001001 2022-10-19 19:41  F356W    SCI MASKA430R                * c Eri ...  630.299        1    1412                               Characterizing 51 Eridani Exoplanetary System     Perrin, Marshall\n",
+       "V01412003001 2022-10-19 23:20  F356W    REF MASKA430R               HD 30562 ...  231.158        5    1412                               Characterizing 51 Eridani Exoplanetary System     Perrin, Marshall\n",
+       "V01412006001 2022-10-20 06:12  F356W    SCI MASKA430R                * c Eri ...  630.299        1    1412                               Characterizing 51 Eridani Exoplanetary System     Perrin, Marshall\n",
+       "V01193014001 2022-10-22 06:13  F356W    SCI MASKA430R              * alf PsA ...  407.997        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
+       "V01193015001 2022-10-22 07:12  F356W    SCI MASKA430R              * alf PsA ...  451.147        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
+       "V01193016001 2022-10-22 07:58  F356W    SCI MASKA430R              * alf PsA ...  451.147        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
+       "V01193017001 2022-10-22 09:09  F356W    SCI MASKA430R              * alf PsA ...  407.997        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
+       "V01193018001 2022-10-22 09:46  F356W    REF MASKA430R              * del Aqr ...  182.085        5    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
+       "V01193019001 2022-10-22 11:16  F356W    REF MASKA430R              * del Aqr ...  150.315        5    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
+       "V01184009001 2022-11-26 15:52  F356W    SCI MASKA335R            FOMALHAUT-C ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184010001 2022-11-26 21:09  F356W    SCI MASKA335R            FOMALHAUT-C ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184011001 2022-11-26 22:34  F356W    SCI MASKA335R              V* AP Col ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184012001 2022-11-27 00:54  F356W    SCI MASKA335R              V* AP Col ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184013001 2022-11-27 02:19  F356W    SCI MASKA335R               G 161-71 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184014001 2022-11-27 04:18  F356W    SCI MASKA335R               G 161-71 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01194001001 2022-11-27 17:40  F356W    SCI MASKA335R                 HR8799 ...  454.854        1    1194          Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
+       "V01194003001 2022-11-27 19:08  F356W    REF MASKA335R            * ups Peg\\` ...   72.777        5    1194          Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
+       "V01194006001 2022-11-27 21:03  F356W    SCI MASKA335R                 HR8799 ...  454.854        1    1194          Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
+       "V01184027001 2023-02-11 14:45  F356W    SCI MASKA335R              LP 776-25 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
+       "V01184028001 2023-02-22 18:16  F356W    SCI MASKA335R              LP 776-25 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import spaceKLIP\n",
+    "\n",
+    "spaceKLIP.mast.query_coron_datasets('NIRCam', 'F356W')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75eb3377",
+   "metadata": {},
+   "source": [
+    "The columns in the above provide information on the observation overall (visit number, date and time, instrument settings, etc), the target and observation label, the duration in seconds and number of dither points used, and which APT program these data are from. \n",
+    "\n",
+    "\n",
+    "Let's see what PSF references are available in MIRI F1550C. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "24711344",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table length=10</i>\n",
+       "<table id=\"table140685155184208\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>visit_id</th><th>start time</th><th>filter</th><th>kind</th><th>coronmsk</th><th>targname</th><th>obslabel</th><th>duration</th><th>numdthpt</th><th>program</th><th>title</th><th>pi_name</th></tr></thead>\n",
+       "<thead><tr><th>str12</th><th>str16</th><th>str6</th><th>bytes3</th><th>str9</th><th>str9</th><th>str25</th><th>float64</th><th>int64</th><th>int64</th><th>str80</th><th>str20</th></tr></thead>\n",
+       "<tr><td>V01045069001</td><td>2022-06-13 17:35</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 92209</td><td>4QPM - F1550C</td><td>774.406</td><td>9</td><td>1045</td><td>MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition</td><td>Dicken, Daniel</td></tr>\n",
+       "<tr><td>V01037010001</td><td>2022-06-18 15:04</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 163113</td><td>4QPM - F1550C</td><td>2299.49</td><td>9</td><td>1037</td><td>MIRI Coronagraphic Contrast Ratios</td><td>Boccaletti, Anthony</td></tr>\n",
+       "<tr><td>V01037011001</td><td>2022-06-18 21:13</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 162989</td><td>Ref 1 deg F1550C</td><td>2299.49</td><td>9</td><td>1037</td><td>MIRI Coronagraphic Contrast Ratios</td><td>Boccaletti, Anthony</td></tr>\n",
+       "<tr><td>V01386007001</td><td>2022-07-17 20:48</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>* phi Cen</td><td>MIRI 1550C - REF</td><td>459.706</td><td>9</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01045088001</td><td>2022-07-19 10:02</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 92209</td><td>4QPM - F1550C</td><td>2299.49</td><td>5</td><td>1045</td><td>MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition</td><td>Dicken, Daniel</td></tr>\n",
+       "<tr><td>V01386027001</td><td>2022-08-02 17:02</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 140986</td><td>MIRI F1550C - REF</td><td>1726.894</td><td>5</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01193004001</td><td>2022-10-21 18:48</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>* 19 PsA</td><td>FomalhautPSF-1550C</td><td>202.29</td><td>9</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01194016001</td><td>2022-11-08 15:17</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 218261</td><td>REF 1550C</td><td>239.92</td><td>9</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01411008001</td><td>2022-12-13 08:54</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>* alf Pic</td><td>Alpha Pic - 1550 4QPM PSF</td><td>725.991</td><td>5</td><td>1411</td><td>Coronagraphy of the Debris Disk Archetype Beta Pictoris</td><td>Stark, Chris</td></tr>\n",
+       "<tr><td>V01241041001</td><td>2023-03-10 19:02</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 49518</td><td>Ref HR 2562 - F1550C</td><td>357.123</td><td>5</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table length=10>\n",
+       "  visit_id      start time    filter  kind   coronmsk  targname          obslabel         duration numdthpt program                                      title                                             pi_name       \n",
+       "   str12          str16        str6  bytes3    str9      str9             str25           float64   int64    int64                                       str80                                              str20        \n",
+       "------------ ---------------- ------ ------ --------- --------- ------------------------- -------- -------- ------- -------------------------------------------------------------------------------- --------------------\n",
+       "V01045069001 2022-06-13 17:35 F1550C    REF 4QPM_1550  HD 92209             4QPM - F1550C  774.406        9    1045 MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition       Dicken, Daniel\n",
+       "V01037010001 2022-06-18 15:04 F1550C    REF 4QPM_1550 HD 163113             4QPM - F1550C  2299.49        9    1037                                               MIRI Coronagraphic Contrast Ratios  Boccaletti, Anthony\n",
+       "V01037011001 2022-06-18 21:13 F1550C    REF 4QPM_1550 HD 162989          Ref 1 deg F1550C  2299.49        9    1037                                               MIRI Coronagraphic Contrast Ratios  Boccaletti, Anthony\n",
+       "V01386007001 2022-07-17 20:48 F1550C    REF 4QPM_1550 * phi Cen          MIRI 1550C - REF  459.706        9    1386           High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
+       "V01045088001 2022-07-19 10:02 F1550C    REF 4QPM_1550  HD 92209             4QPM - F1550C  2299.49        5    1045 MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition       Dicken, Daniel\n",
+       "V01386027001 2022-08-02 17:02 F1550C    REF 4QPM_1550 HD 140986         MIRI F1550C - REF 1726.894        5    1386           High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
+       "V01193004001 2022-10-21 18:48 F1550C    REF 4QPM_1550  * 19 PsA        FomalhautPSF-1550C   202.29        9    1193      Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
+       "V01194016001 2022-11-08 15:17 F1550C    REF 4QPM_1550 HD 218261                 REF 1550C   239.92        9    1194               Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
+       "V01411008001 2022-12-13 08:54 F1550C    REF 4QPM_1550 * alf Pic Alpha Pic - 1550 4QPM PSF  725.991        5    1411                          Coronagraphy of the Debris Disk Archetype Beta Pictoris         Stark, Chris\n",
+       "V01241041001 2023-03-10 19:02 F1550C    REF 4QPM_1550  HD 49518      Ref HR 2562 - F1550C  357.123        5    1241                                         MIRI Coronagraphic Imaging of exoplanets  Ressler, Michael E."
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spaceKLIP.mast.query_coron_datasets('MIRI', 'F1550C', kind='REF')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad784879",
+   "metadata": {},
+   "source": [
+    "And similarly for background observations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3536a7e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table length=13</i>\n",
+       "<table id=\"table140685166977184\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>visit_id</th><th>start time</th><th>filter</th><th>kind</th><th>coronmsk</th><th>targname</th><th>obslabel</th><th>duration</th><th>numdthpt</th><th>program</th><th>title</th><th>pi_name</th></tr></thead>\n",
+       "<thead><tr><th>str12</th><th>str16</th><th>str6</th><th>bytes3</th><th>str9</th><th>str21</th><th>str36</th><th>float64</th><th>int64</th><th>int64</th><th>str75</th><th>str20</th></tr></thead>\n",
+       "<tr><td>V01386030001</td><td>2022-07-18 02:42</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>MIRI 1550C - Target BG</td><td>3609.341</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386031001</td><td>2022-07-18 04:53</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>MIRI 1550C - REF BG</td><td>459.706</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386036001</td><td>2022-08-02 19:57</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>MIRI F1550C - Target BG</td><td>3741.884</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386037001</td><td>2022-08-02 22:29</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>MIRI F1550C - REF BG</td><td>1726.894</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01193005001</td><td>2022-10-21 19:43</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>* 19 PsA</td><td>FomalhautPSF-1550C-background</td><td>202.29</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01193010001</td><td>2022-10-21 22:42</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>FOMALHAUT-F1550C-BACK</td><td>Fomalhaut-F1550C-background</td><td>914.379</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01194011001</td><td>2022-11-08 10:18</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>1550C - Target Bkg</td><td>4322.629</td><td>2</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01194018001</td><td>2022-11-08 16:18</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>1550C - REF Bkg</td><td>239.92</td><td>2</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01406030001</td><td>2022-11-29 05:12</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>HD 161617</td><td>1550-BGND</td><td>508.122</td><td>2</td><td>1406</td><td>Verification of the MIRI Coronagraphic Target Acquisition</td><td>Hines, Dean C.</td></tr>\n",
+       "<tr><td>V01411001001</td><td>2022-12-13 00:10</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>Beta Pic Background - 1550 4QPM</td><td>1331.183</td><td>2</td><td>1411</td><td>Coronagraphy of the Debris Disk Archetype Beta Pictoris</td><td>Stark, Chris</td></tr>\n",
+       "<tr><td>V01411009001</td><td>2022-12-13 10:17</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>Alpha Pic Background - 1550 4QPM PSF</td><td>725.991</td><td>2</td><td>1411</td><td>Coronagraphy of the Debris Disk Archetype Beta Pictoris</td><td>Stark, Chris</td></tr>\n",
+       "<tr><td>V01241033001</td><td>2023-03-10 15:05</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>HR 2562 Background</td><td>HR 2562 Bckgr - F1550C</td><td>1199.119</td><td>2</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
+       "<tr><td>V01241044001</td><td>2023-03-10 20:22</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>HD 49518 Background</td><td>Ref HR 2562 Bckgr - F1550C</td><td>357.123</td><td>2</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table length=13>\n",
+       "  visit_id      start time    filter  kind   coronmsk        targname                     obslabel               duration numdthpt program                                    title                                          pi_name       \n",
+       "   str12          str16        str6  bytes3    str9           str21                        str36                 float64   int64    int64                                     str75                                           str20        \n",
+       "------------ ---------------- ------ ------ --------- --------------------- ------------------------------------ -------- -------- ------- --------------------------------------------------------------------------- --------------------\n",
+       "V01386030001 2022-07-18 02:42 F1550C    BKG 4QPM_1550                   N/A               MIRI 1550C - Target BG 3609.341        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
+       "V01386031001 2022-07-18 04:53 F1550C    BKG 4QPM_1550                   N/A                  MIRI 1550C - REF BG  459.706        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
+       "V01386036001 2022-08-02 19:57 F1550C    BKG 4QPM_1550                   N/A              MIRI F1550C - Target BG 3741.884        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
+       "V01386037001 2022-08-02 22:29 F1550C    BKG 4QPM_1550                   N/A                 MIRI F1550C - REF BG 1726.894        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
+       "V01193005001 2022-10-21 19:43 F1550C    BKG 4QPM_1550              * 19 PsA        FomalhautPSF-1550C-background   202.29        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
+       "V01193010001 2022-10-21 22:42 F1550C    BKG 4QPM_1550 FOMALHAUT-F1550C-BACK          Fomalhaut-F1550C-background  914.379        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
+       "V01194011001 2022-11-08 10:18 F1550C    BKG 4QPM_1550                   N/A                   1550C - Target Bkg 4322.629        2    1194          Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
+       "V01194018001 2022-11-08 16:18 F1550C    BKG 4QPM_1550                   N/A                      1550C - REF Bkg   239.92        2    1194          Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
+       "V01406030001 2022-11-29 05:12 F1550C    BKG 4QPM_1550             HD 161617                            1550-BGND  508.122        2    1406                   Verification of the MIRI Coronagraphic Target Acquisition       Hines, Dean C.\n",
+       "V01411001001 2022-12-13 00:10 F1550C    BKG 4QPM_1550                   N/A      Beta Pic Background - 1550 4QPM 1331.183        2    1411                     Coronagraphy of the Debris Disk Archetype Beta Pictoris         Stark, Chris\n",
+       "V01411009001 2022-12-13 10:17 F1550C    BKG 4QPM_1550                   N/A Alpha Pic Background - 1550 4QPM PSF  725.991        2    1411                     Coronagraphy of the Debris Disk Archetype Beta Pictoris         Stark, Chris\n",
+       "V01241033001 2023-03-10 15:05 F1550C    BKG 4QPM_1550    HR 2562 Background               HR 2562 Bckgr - F1550C 1199.119        2    1241                                    MIRI Coronagraphic Imaging of exoplanets  Ressler, Michael E.\n",
+       "V01241044001 2023-03-10 20:22 F1550C    BKG 4QPM_1550   HD 49518 Background           Ref HR 2562 Bckgr - F1550C  357.123        2    1241                                    MIRI Coronagraphic Imaging of exoplanets  Ressler, Michael E."
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spaceKLIP.mast.query_coron_datasets('MIRI', 'F1550C', kind='BKG')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb6ac4c5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/spaceKLIP/mast.py
+++ b/spaceKLIP/mast.py
@@ -1,0 +1,110 @@
+import numpy as np
+import astroquery, astropy
+from astroquery.mast import Mast
+
+
+
+def set_params(parameters):
+    """Utility function for making dicts used in MAST queries"""
+    return [{"paramName":p, "values":v} for p,v in parameters.items()]
+
+
+def query_coron_datasets(inst, filt, mask=None, kind=None, ignore_cal=True):
+    """Query MAST to make a summary table of existing JWST coronagraphic datasets
+
+    Parameters
+    ----------
+
+    inst : str
+        'MIRI' or 'NIRCam'. Required.
+    filt : str
+        Filter name, like 'F356W'. Required.
+    mask : str
+        Coronagraph mask name, like "MASKA335R" or "4QPM_1550". Optional.
+        If provided, must exactly match the keyword value as used in MAST, which isn't
+        always what you might expect. In particular you need to explicitly include the "A"
+        for NIRCam module A in e.g. "MASKA335R"
+    kind : str
+        'SCI' for science targets, or 'REF' for PSF references, or 'BKG' for backgrounds.
+    ignore_cal : bool
+        Ignore/exclude any category='CAL' calibration programs. This can be desirable to ignore
+        the NIRCam coronagraphic flux calibration data sets, which otherwise look like
+        science data to this query. (programs 1537,1538 for example)
+
+    """
+
+    # Perform MAST query to find all available datasets for a given filter/occulter
+
+    if inst.upper()=='MIRI':
+        service = "Mast.Jwst.Filtered.Miri"
+        template ='MIRI Coronagraphic Imaging'
+    else:
+        service = "Mast.Jwst.Filtered.NIRCam"
+        template = 'NIRCam Coronagraphic Imaging'
+
+    keywords = {
+        'filter': [filt],
+        #f'apername': [f'MIRIM_MASK{filt}'],
+        'template': [template],
+        'productLevel': ['2b'],
+    }
+
+    if mask is not None:
+        keywords['coronmsk'] = [mask]
+    if ignore_cal:
+        keywords['category'] = ['COM','ERS', 'GTO', 'GO']  # but not CAL
+
+    # Optional, restrict to one kind of coronagraphic data
+    if kind=='SCI':
+        keywords['is_psf'] = ['f']
+        keywords['bkgdtarg'] = ['f']
+    elif kind=='REF':
+        keywords['is_psf'] = ['t']
+        keywords['bkgdtarg'] = ['f']
+    elif kind=='BKG':
+        keywords['is_psf'] = ['f']
+        keywords['bkgdtarg'] = ['t']
+
+
+	# Method note: We query MAST for much more than we actually need / want, and then filter down afterwards.
+    #  This is not entirely necessary, but leaves room for future expansion to add options for more verbose output, etc.
+    #  Currently this works by retrieving all level2b (i.e. cal / calints) files, including all dithers etc, and then
+    #  trimming to one unique row per observation.
+
+    collist = 'filename, productLevel, bkgdtarg, bstrtime, duration, effexptm, effinttm, exp_type, filter, coronmsk, is_psf, nexposur, nframes, nints, numdthpt, obs_id, obslabel, pi_name, program, subarray, targname, template, title, visit_id, visitsta, vststart_mjd, isRestricted'
+    all_columns=False
+
+    parameters = {"columns": "*" if all_columns else collist,
+                   "filters": set_params(keywords)}
+
+    response = Mast.service_request(service, parameters)
+    response.sort(keys = 'bstrtime')
+
+
+    # Summarize the distinct observations conveniently
+    cols_to_keep = ['visit_id',  'filter', 'coronmsk', 'targname', 'obslabel', 'duration',
+                    'numdthpt', 'program', 'title', 'pi_name',]
+
+    summarytable = astropy.table.Table([response.columns[cname].filled() for cname in cols_to_keep],
+                                       masked=False, copy=True)
+    # Add the initial V to visit ID
+    summarytable['visit_id'] = astropy.table.Column(summarytable['visit_id'], dtype=np.dtype('<U12'))
+    for row in summarytable:
+        row['visit_id'] = "V" + row['visit_id']
+
+    # Add a summary for which kind of observation each is
+    kind = np.zeros(len(response), dtype='a3')
+    kind[:] = "SCI" # by default assume sci, then check for ref and BG
+    kind[response.columns['is_psf']=='t'] = 'REF'
+    kind[response.columns['bkgdtarg']=='t'] = 'BKG'
+    kind[kind==''] = 'SCI'
+    summarytable.add_column( astropy.table.Column(kind), index=2, name='kind')
+
+    summarytable.add_column( astropy.table.Column(astropy.time.Time(response['vststart_mjd'], format='mjd').iso,dtype=np.dtype('<U16') ),
+                            index=1, name='start time')
+
+
+    summarytable = astropy.table.unique(summarytable)
+    summarytable.sort(keys='start time')
+
+    return summarytable


### PR DESCRIPTION
This PR adds a function `spaceKLIP.mast.query_coron_datasets` for searching MAST for available coronagraphic science, PSF reference, and/or background data.  This PR includes the code and an example notebook. 

Example usage is like:

```py
# Find all available NIRCam PSF references in a given filter for the 335R mask
query_coron_datasets('NIRCam', 'F335M', 'MASKA335R', kind='REF')

# Find all MIRI 15 micron background observations
query_coron_datasets('MIRI', 'F1550C', kind='BKG')

```

The returned output is an astropy table like: 

<img width="912" alt="Screen Shot 2023-03-15 at 5 21 31 PM" src="https://user-images.githubusercontent.com/1151745/225446688-202e1ca1-4743-47ae-a172-ff7d5953150d.png">
[additional rows not shown]


