### PR TITLE
start updating docs for spaceklip 2.0

### DIFF
--- a/docs/source/Attribution.rst
+++ b/docs/source/Attribution.rst
@@ -3,3 +3,13 @@ Attribution
 
 Maintenance and current development of ``spaceKLIP`` is led by Aaryn Carter and Jens Kammerer. spaceKLIP also benefitted from contributions made by a number of collaborators.
 More details about the respective contributions are available `here <https://github.com/kammerje/spaceKLIP/graphs/contributors>`_.
+
+
+.. note::
+   **Citing spaceKLIP:** 
+   If spaceKLIP is useful for your research, 
+   please cite 
+   `Kammerer et al. 2022, Proc SPIE. <https://ui.adsabs.harvard.edu/abs/2022SPIE12180E..3NK/abstract>`_ and
+   `Carter et al. 2023, ApJL <https://ui.adsabs.harvard.edu/abs/2023ApJ...951L..20C/abstract>`_. 
+
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,14 +23,9 @@ import sys
 import matplotlib
 matplotlib.use("agg")
 
+import spaceKLIP
 
-sys.path.insert(0, os.path.abspath('../../spaceKLIP/'))
-
-with open(os.path.join(os.path.abspath('../../spaceKLIP/'), '__init__.py')) as init:
-    for line in init:
-        if "__version__ =" in line:
-            version = line.split('"')[1]
-
+version = spaceKLIP.__version__
 
 # -- General configuration ------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,5 @@
 .. This file should at least contain the root `toctree` directive.
 
-.. Welcome to ``spaceKLIP``'s documentation
-.. ========================================
 
 Documentation for spaceKLIP
 ===========================
@@ -10,10 +8,20 @@ Documentation for spaceKLIP
    :align: center
    :width: 400px
 
-spaceKLIP is a data reduction pipeline for JWST high contrast imaging. 
+spaceKLIP is a data reduction pipeline for JWST high contrast imaging, particularly NIRCam and MIRI coronagraphy.
+It is built on top of `pyKLIP <https://pyklip.readthedocs.io/en/latest/>`_ and provides functionality and customizations specific to JWST data. 
 
 All code is currently under heavy development
 and typically expected features may not be available. 
+
+
+.. note::
+   **Citing spaceKLIP:** 
+   If spaceKLIP is useful for your research, 
+   please cite 
+   `Kammerer et al. 2022, Proc SPIE. <https://ui.adsabs.harvard.edu/abs/2022SPIE12180E..3NK/abstract>`_ and
+   `Carter et al. 2023, ApJL <https://ui.adsabs.harvard.edu/abs/2023ApJ...951L..20C/abstract>`_. 
+
 
 Compatible Simulated Data: `Here <https://stsci.box.com/s/cktghuyrwrallb401rw5y5da2g5ije6t>`_
 

--- a/docs/source/spaceKLIP.rst
+++ b/docs/source/spaceKLIP.rst
@@ -4,42 +4,74 @@ spaceKLIP package
 Submodules
 ----------
 
-spaceKLIP.companion module
---------------------------
+spaceKLIP.analysistools module
+------------------------------
 
-.. automodule:: spaceKLIP.companion
+.. automodule:: spaceKLIP.analysistools
    :members:
    :undoc-members:
    :show-inheritance:
 
-spaceKLIP.contrast module
+spaceKLIP.classpsfsubpipeline module
+------------------------------------
+
+.. automodule:: spaceKLIP.classpsfsubpipeline
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+spaceKLIP.coron1pipeline module
+-------------------------------
+
+.. automodule:: spaceKLIP.coron1pipeline
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+spaceKLIP.coron2pipeline module
+-------------------------------
+
+.. automodule:: spaceKLIP.coron2pipeline
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+spaceKLIP.coron3pipeline module
+-------------------------------
+
+.. automodule:: spaceKLIP.coron3pipeline
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+spaceKLIP.database module
 -------------------------
 
-.. automodule:: spaceKLIP.contrast
+.. automodule:: spaceKLIP.database
    :members:
    :undoc-members:
    :show-inheritance:
 
-spaceKLIP.engine module
------------------------
-
-.. automodule:: spaceKLIP.engine
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-spaceKLIP.imgprocess module
+spaceKLIP.imagetools module
 ---------------------------
 
-.. automodule:: spaceKLIP.imgprocess
+.. automodule:: spaceKLIP.imagetools
    :members:
    :undoc-members:
    :show-inheritance:
 
-spaceKLIP.io module
--------------------
+spaceKLIP.make\_psfmasks module
+-------------------------------
 
-.. automodule:: spaceKLIP.io
+.. automodule:: spaceKLIP.make_psfmasks
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+spaceKLIP.mast module
+---------------------
+
+.. automodule:: spaceKLIP.mast
    :members:
    :undoc-members:
    :show-inheritance:
@@ -52,18 +84,26 @@ spaceKLIP.plotting module
    :undoc-members:
    :show-inheritance:
 
-spaceKLIP.rampfit module
-------------------------
+spaceKLIP.psf module
+--------------------
 
-.. automodule:: spaceKLIP.rampfit
+.. automodule:: spaceKLIP.psf
    :members:
    :undoc-members:
    :show-inheritance:
 
-spaceKLIP.subtraction module
-----------------------------
+spaceKLIP.pyklippipeline module
+-------------------------------
 
-.. automodule:: spaceKLIP.subtraction
+.. automodule:: spaceKLIP.pyklippipeline
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+spaceKLIP.starphot module
+-------------------------
+
+.. automodule:: spaceKLIP.starphot
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
Updates docs framework with sphinx-apidoc. Add citation information. 

Replaces https://github.com/kammerje/spaceKLIP_new/pull/23 from the spaceklip_new repo