### PR TITLE
update database.summarize() and plotting.display_coron_dataset() to support pyKLIP outputs

### DIFF
--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -1237,14 +1237,32 @@ class Database():
         for mode in self.obs:
             print(short_concat_name(mode))
             tab = self.obs[mode]
-            for stage in [0, 1, 2, 3]:
+            for stage in [0, 1, 2]:
                 stagetab = tab[tab['DATAMODL'] == f'STAGE{stage}']
                 if len(stagetab):
                     nsci = np.sum(stagetab['TYPE'] == 'SCI')
                     nref = np.sum(stagetab['TYPE'] == 'REF')
                     nta = np.sum((stagetab['TYPE'] == 'SCI_TA') | (stagetab['TYPE'] == 'REF_TA'))
+                    nbg = np.sum((stagetab['TYPE'] == 'SCI_BG') | (stagetab['TYPE'] == 'REF_BG'))
                     
                     summarystr = f'\tSTAGE{stage}: {len(stagetab)} files;\t{nsci} SCI, {nref} REF'
                     if nta:
                         summarystr += f', {nta} TA'
+                    if nbg:
+                        summarystr += f', {nbg} BG'
                     print(summarystr)
+            if hasattr(self, 'red') and mode in self.red:
+                tab = self.red[mode]
+                stage = 3
+                stagetab = tab[tab['DATAMODL'] == f'STAGE{stage}']
+                if len(stagetab):
+                    s3types = sorted(list(set(tab['TYPE'].value)))
+                    nta = np.sum((stagetab['TYPE'] == 'SCI_TA') | (stagetab['TYPE'] == 'REF_TA'))
+                    nbg = np.sum((stagetab['TYPE'] == 'SCI_BG') | (stagetab['TYPE'] == 'REF_BG'))
+
+                    summarystr = f'\tSTAGE{stage}: {len(stagetab)} files;\t'
+                    for i, typestr in enumerate(s3types):
+                        ntype = np.sum(stagetab['TYPE'] == typestr)
+                        summarystr += (', ' if i>0 else '') + f'{ntype} {typestr}'
+                    print(summarystr)
+

--- a/spaceKLIP/plotting.py
+++ b/spaceKLIP/plotting.py
@@ -12,7 +12,7 @@ import os
 import pdb
 import sys
 
-import astropy.io.fits as pyfits
+import astropy.io.fits as fits
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -178,26 +178,48 @@ def display_coron_image(filename):
     
     """
     
+    is_pyklip = False
     if ('uncal' in filename):
         raise RuntimeError("Display code does not support showing stage 0 uncal files. Reduce the data further before trying to display it.")
+    elif 'KLmodes' in filename:
+        # PyKLIP output, we have to open this differently, can't use JWST datamodels
+        is_pyklip = True
+
     elif ('rateints' in filename) or ('calints' in filename):
         modeltype = jwst.datamodels.CubeModel
         cube = True
     else:
         modeltype = jwst.datamodels.ImageModel
         cube = False
-    
-    model = modeltype(filename)  # cubemodel needed for rateints
-    
-    if cube:
-        image = np.nanmean(model.data, axis=0)
-        dq = model.dq[0]
+    if not is_pyklip:
+
+        model = modeltype(filename)  # cubemodel needed for rateints
+        
+        if cube:
+            image = np.nanmean(model.data, axis=0)
+            dq = model.dq[0]
+            nints = model.meta.nints
+        else:
+            image = model.data
+            dq = model.dq
+        bunit = model.meta.bunit_data
+
+        annotation_text = f"{model.meta.target.proposer_name}\n{model.meta.instrument.filter}, {model.meta.exposure.readpatt}:{model.meta.exposure.ngroups}:{model.meta.exposure.nints}\n{model.meta.exposure.effective_exposure_time:.2f} s",
     else:
-        image = model.data
-        dq = model.dq
+        image = fits.getdata(filename)
+        header= fits.getheader(filename)
+        bunit = header['BUNIT']
+        if len(image.shape)==3:
+            image = image[-1] # select the last KL mode
+        annotation_text = f"pyKLIP results for {header['TARGPROP']}\n{header['FILTER']}\n",
     
     bpmask = np.zeros_like(image) + np.nan
-    bpmask[(model.dq[0] & 1) == True] = 1
+    # does this file have DQ extension or not? PyKLIP outputs do not
+    if is_pyklip:
+        bpmask[np.isfinite(image)] = 1
+    else:
+        bpmask[(model.dq[0] & 1) == True] = 1
+        
     
     # Set up image stretch
     #  including reasonable min/max for asinh stretch
@@ -219,12 +241,11 @@ def display_coron_image(filename):
     imdq = ax.imshow(bpmask, vmin=0, vmax=1.5, cmap=matplotlib.cm.inferno)
     
     # Colorbar
-    cb = fig.colorbar(im, pad=0.1, aspect=30, label=model.meta.bunit_data)
+    cb = fig.colorbar(im, pad=0.1, aspect=30, label=bunit)
     cb.ax.set_yscale('asinh')
     
     # Annotations
-    ax.text(0.01, 0.99,
-            f"{model.meta.target.proposer_name}\n{model.meta.instrument.filter}, {model.meta.exposure.readpatt}:{model.meta.exposure.ngroups}:{model.meta.exposure.nints}\n{model.meta.exposure.effective_exposure_time:.2f} s",
+    ax.text(0.01, 0.99, annotation_text,
             transform=ax.transAxes, color='white', verticalalignment='top', fontsize=10)
     ax.set_title(os.path.basename(filename) + "\n", fontsize=14)
     
@@ -233,7 +254,7 @@ def display_coron_image(filename):
     ax.tick_params(labelsize='small')
     
     if cube:
-        ax.text(0.99, 0.99, f"Showing average of {model.meta.exposure.nints} ints",
+        ax.text(0.99, 0.99, f"Showing average of {nints} ints",
                 style='italic', fontsize=10, color='white',
                 horizontalalignment='right', verticalalignment='top', transform=ax.transAxes)
     
@@ -257,7 +278,7 @@ def display_coron_image(filename):
     # TODO:
     #   add second panel with zoom in on center
 
-def display_coron_dataset(database, restrict_to=None, save_filename=None):
+def display_coron_dataset(database, restrict_to=None, save_filename=None, stage3=None):
     """
     Display multiple files in a coronagraphic dataset.
     
@@ -283,16 +304,36 @@ def display_coron_dataset(database, restrict_to=None, save_filename=None):
     if save_filename:
         from matplotlib.backends.backend_pdf import PdfPages
         pdf = PdfPages(save_filename)
-    
-    for key in database.obs:
-        if (restrict_to is None) or (restrict_to in key):
-            obstable = database.obs[key]
-            for typestr in ['SCI', 'REF']:
-                filenames = obstable[obstable['TYPE'] == typestr]['FITSFILE']
-                
-                for fn in filenames:
-                    display_coron_image(fn)
-                    if save_filename:
-                        pdf.savefig(plt.gcf())
+
+    if stage3 is None:
+        # infer based on db contents whether we have stage3 data or not
+        if hasattr(database, 'red') and len(database.red)>0:
+            stage3 = True
+        else:
+            stage3 = False
+    if not stage3:
+        # Display stage 0,1,2 data
+        for key in database.obs:
+            if (restrict_to is None) or (restrict_to in key):
+                obstable = database.obs[key]
+                for typestr in ['SCI', 'REF']:
+                    filenames = obstable[obstable['TYPE'] == typestr]['FITSFILE']
+                    
+                    for fn in filenames:
+                        display_coron_image(fn)
+                        if save_filename:
+                            pdf.savefig(plt.gcf())
+    else:
+        for key in database.red:
+            if (restrict_to is None) or (restrict_to in key):
+                redtable = database.red[key]
+                for typestr in ['PYKLIP','STAGE3']:
+                    filenames = redtable[redtable['TYPE'] == typestr]['FITSFILE']
+                    
+                    for fn in filenames:
+                        display_coron_image(fn)
+                        if save_filename:
+                            pdf.savefig(plt.gcf())
+ 
     if save_filename:
         pdf.close()


### PR DESCRIPTION
- enhance `database.summarize` function to also look at database.red as well as database.obs, and print a summary of the reduced files. 
- enhance display_coron_dataset to know about stage3 files from database.red, and also display those. (Requires some extra steps in the plotting function since the pyklip outputs are organized differently than jwst pipeline outputs, so have to be read in differently.)

The plotting needs some more work and debugging still. But wanted to submit this as a draft for now
