### PR TITLE
Bookkeeping

### DIFF
--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -144,7 +144,7 @@ class AnalysisTools():
                 mask = ut.read_msk(maskfile)
                 
                 # Compute the pixel area in steradian.
-                pxsc_arcsec = self.database.red[key]['PIXSCALE'][j] / 1000.  # arcsec
+                pxsc_arcsec = self.database.red[key]['PIXSCALE'][j] # arcsec
                 pxsc_rad = pxsc_arcsec / 3600. / 180. * np.pi  # rad
                 pxar = pxsc_rad**2  # sr
                 
@@ -219,7 +219,7 @@ class AnalysisTools():
                 cons = []
                 for k in range(data.shape[0]):
                     sep, con = klip.meas_contrast(dat=data[k] * pxar / fstar, iwa=iwa, owa=owa, resolution=resolution, center=center, low_pass_filter=False)
-                    seps += [sep * self.database.red[key]['PIXSCALE'][j] / 1000.]   # arcsec
+                    seps += [sep * self.database.red[key]['PIXSCALE'][j]]   # arcsec
                     cons += [con]
                 seps = np.array(seps)
                 cons = np.array(cons)
@@ -411,7 +411,7 @@ class AnalysisTools():
                                                  self.database.red[key]['FILTER'][j])
                 
                 # Compute the pixel area in steradian.
-                pxsc_arcsec = self.database.red[key]['PIXSCALE'][j] / 1000.  # arcsec
+                pxsc_arcsec = self.database.red[key]['PIXSCALE'][j] # arcsec
                 pxsc_rad = pxsc_arcsec / 3600. / 180. * np.pi  # rad
                 pxar = pxsc_rad**2  # sr
                 

--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -169,7 +169,7 @@ class AnalysisTools():
                     raise UserWarning('Data originates from unknown telescope')
                 resolution = 1e-6 * self.database.red[key]['CWAVEL'][j] / diam / pxsc_rad  # pix
                 if not np.isnan(self.database.obs[key]['BLURFWHM'][j]):
-                    resolution *= self.database.obs[key]['BLURFWHM'][j]
+                    resolution = np.hypot(resolution, self.database.obs[key]['BLURFWHM'][j])
                 
                 # Get the star position.
                 if overwrite_crpix is None:
@@ -426,7 +426,7 @@ class AnalysisTools():
                     raise UserWarning('Data originates from unknown telescope')
                 resolution = 1e-6 * self.database.red[key]['CWAVEL'][j] / diam / pxsc_rad  # pix
                 if not np.isnan(self.database.obs[key]['BLURFWHM'][j]):
-                    resolution *= self.database.obs[key]['BLURFWHM'][j]
+                    resolution = np.hypot(resolution, self.database.obs[key]['BLURFWHM'][j])
                 
                 # Find science and reference files.
                 filepaths = []
@@ -669,7 +669,8 @@ class AnalysisTools():
                         
                         # Blur frames with a Gaussian filter.
                         if not np.isnan(self.database.obs[key]['BLURFWHM'][ww]):
-                            offsetpsf = gaussian_filter(offsetpsf, self.database.obs[key]['BLURFWHM'][ww])
+                            gauss_sigma = self.database.obs[key]['BLURFWHM'][j] / np.sqrt(8. * np.log(2.))
+                            offsetpsf = gaussian_filter(offsetpsf, gauss_sigma)
                         
                         # Apply high-pass filter.
                         offsetpsf_nohpf = copy.deepcopy(offsetpsf)

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -201,10 +201,10 @@ class Database():
         SELFREF = []
         SUBARRAY = []
         NUMDTHPT = []
-        XOFFSET = []  # mas
-        YOFFSET = []  # mas
+        XOFFSET = []  # arcsec
+        YOFFSET = []  # arcsec
         APERNAME = []
-        PIXSCALE = []  # mas
+        PIXSCALE = []  # arcsec
         BUNIT = []
         CRPIX1 = []  # pix
         CRPIX2 = []  # pix
@@ -267,19 +267,19 @@ class Database():
             SELFREF += [str(head.get('SELFREF', 'NONE'))]
             SUBARRAY += [head.get('SUBARRAY', 'UNKNOWN')]
             NUMDTHPT += [head.get('NUMDTHPT', 1)]
-            XOFFSET += [1e3 * head.get('XOFFSET', 0.)]
-            YOFFSET += [1e3 * head.get('YOFFSET', 0.)]
+            XOFFSET += [head.get('XOFFSET', 0.)]
+            YOFFSET += [head.get('YOFFSET', 0.)]
             APERNAME += [head.get('APERNAME', 'UNKNOWN')]
             if TELESCOP[-1] == 'JWST':
                 if INSTRUME[-1] == 'NIRCAM':
                     if 'LONG' in DETECTOR[-1] or '5' in DETECTOR[-1]:
-                        PIXSCALE += [nircam._pixelscale_long * 1e3]
+                        PIXSCALE += [nircam._pixelscale_long]
                     else:
-                        PIXSCALE += [nircam._pixelscale_short * 1e3]
+                        PIXSCALE += [nircam._pixelscale_short]
                 elif INSTRUME[-1] == 'NIRISS':
-                    PIXSCALE += [niriss.pixelscale * 1e3]
+                    PIXSCALE += [niriss.pixelscale]
                 elif INSTRUME[-1] == 'MIRI':
-                    PIXSCALE += [miri.pixelscale * 1e3]
+                    PIXSCALE += [miri.pixelscale]
                 else:
                     raise UserWarning('Data originates from unknown JWST instrument')
             else:
@@ -628,7 +628,7 @@ class Database():
         EFFINTTM = []  # s
         SUBARRAY = []
         APERNAME = []
-        PIXSCALE = []  # mas
+        PIXSCALE = []  # arcsec
         MODE = []
         ANNULI = []
         SUBSECTS = []
@@ -685,13 +685,13 @@ class Database():
             if TELESCOP[-1] == 'JWST':
                 if INSTRUME[-1] == 'NIRCAM':
                     if 'LONG' in DETECTOR[-1] or '5' in DETECTOR[-1]:
-                        PIXSCALE += [nircam._pixelscale_long * 1e3]
+                        PIXSCALE += [nircam._pixelscale_long]
                     else:
-                        PIXSCALE += [nircam._pixelscale_short * 1e3]
+                        PIXSCALE += [nircam._pixelscale_short]
                 elif INSTRUME[-1] == 'NIRISS':
-                    PIXSCALE += [niriss.pixelscale * 1e3]
+                    PIXSCALE += [niriss.pixelscale]
                 elif INSTRUME[-1] == 'MIRI':
-                    PIXSCALE += [miri.pixelscale * 1e3]
+                    PIXSCALE += [miri.pixelscale]
                 else:
                     raise UserWarning('Data originates from unknown JWST instrument')
             else:

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -1325,7 +1325,7 @@ class ImageTools():
                 if fact_temp is None:
                     pass
                 else:
-                    head_pri['BLURFWHM'] = fact_temp
+                    head_pri['BLURFWHM'] = fact_temp * np.sqrt(8. * np.log(2.)) # Factor to convert from sigma to FWHM
                 fitsfile = ut.write_obs(fitsfile, output_dir, data, erro, pxdq, head_pri, head_sci, is2d, imshifts, maskoffs)
                 maskfile = ut.write_msk(maskfile, mask, fitsfile)
                 
@@ -1793,7 +1793,8 @@ class ImageTools():
         # model_psf = psf.gen_psf_idl(crtel, coord_frame='tel', return_oversample=False)
         model_psf = psf.gen_psf_idl((0, 0), coord_frame='idl', return_oversample=False)  # using this instead after discussing with Jarron
         if not np.isnan(self.database.obs[key]['BLURFWHM'][j]):
-            model_psf = gaussian_filter(model_psf, self.database.obs[key]['BLURFWHM'][j])
+            gauss_sigma = self.database.obs[key]['BLURFWHM'][j] / np.sqrt(8. * np.log(2.))
+            model_psf = gaussian_filter(model_psf, gauss_sigma)
         
         # Get transmission mask.
         yi, xi = np.indices(data0.shape)

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -2054,19 +2054,19 @@ class ImageTools():
             syms = ['o', 'v', '^', '<', '>'] * (1 + len(ww_ref) // 5)
             add = len(ww_sci)
             for index, j in enumerate(ww_ref):
-                this = '%.0f_%.0f' % (database_temp[key]['XOFFSET'][j], database_temp[key]['YOFFSET'][j])
+                this = '%.3f_%.3f' % (database_temp[key]['XOFFSET'][j], database_temp[key]['YOFFSET'][j])
                 if this not in seen:
                     ax.scatter(shifts_all[index + add][:, 0] * self.database.obs[key]['PIXSCALE'][j] * 1000, 
                                shifts_all[index + add][:, 1] * self.database.obs[key]['PIXSCALE'][j] * 1000, 
                                s=5, color=colors[len(seen)], marker=syms[0], 
                                label='dither %.0f' % (len(seen) + 1))
                     ax.hlines((-database_temp[key]['YOFFSET'][j] + yoffset)*1000, 
-                              (-database_temp[key]['XOFFSET'][j] + xoffset - 4.)*1000, 
-                              (-database_temp[key]['XOFFSET'][j] + xoffset + 4.)*1000,
+                              (-database_temp[key]['XOFFSET'][j] + xoffset)*1000 - 4., 
+                              (-database_temp[key]['XOFFSET'][j] + xoffset)*1000 + 4.,
                               color=colors[len(seen)], lw=1)
                     ax.vlines((-database_temp[key]['XOFFSET'][j] + xoffset)*1000, 
-                              (-database_temp[key]['YOFFSET'][j] + yoffset - 4.)*1000, 
-                              (-database_temp[key]['YOFFSET'][j] + yoffset + 4.)*1000, 
+                              (-database_temp[key]['YOFFSET'][j] + yoffset)*1000 - 4., 
+                              (-database_temp[key]['YOFFSET'][j] + yoffset)*1000 + 4., 
                               color=colors[len(seen)], lw=1)
                     seen += [this]
                     reps += [1]

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -191,7 +191,7 @@ class SpaceTelescope(Data):
         PAs_all = []  # deg
         wvs_all = []  # m
         wcs_all = []
-        PIXSCALE = []  # mas
+        PIXSCALE = []  # arcsec
         for i, filepath in enumerate(filepaths):
             
             # Read science file.
@@ -237,9 +237,9 @@ class SpaceTelescope(Data):
         if len(PIXSCALE) != 1:
             raise UserWarning('Some science files do not have matching pixel scales')
         if TELESCOP == 'JWST' and obs['EXP_TYPE'][ww] in ['NRC_CORON', 'MIR_LYOT']:
-            iwa_all = np.min(wvs_all) / 6.5 * 180. / np.pi * 3600. * 1000. / PIXSCALE[0]  # pix
+            iwa_all = np.min(wvs_all) / 6.5 * 180. / np.pi * 3600. / PIXSCALE[0]  # pix
         elif TELESCOP == 'JWST' and obs['EXP_TYPE'][ww] in ['MIR_4QPM']:
-            iwa_all = 0.5 * np.min(wvs_all) / 6.5 * 180. / np.pi * 3600. * 1000. / PIXSCALE[0]  # pix
+            iwa_all = 0.5 * np.min(wvs_all) / 6.5 * 180. / np.pi * 3600. / PIXSCALE[0]  # pix
         else:
             iwa_all = 1.  # pix
         


### PR DESCRIPTION
Made improvements to general book keeping for a few things.

1) XOFFSET and YOFFSET are now always recorded in arcseconds. This is the same unit that the default pipeline uses and will ensure future compatibility with the newer version of pyKLIP. 
2) BLURFWHM is now always recorded as the FWHM, and not sigma, of the Gaussian to use for blurring. Additionally, adjusted how the blur is applied when scaling the resolution during the contrast curve calculation. 

Checked with the NIRCam ERS F300M data and looks like the resolution of the contrast curves is being correctly adjusted now. Resolves #93 
