### PR TITLE
Part 2 of #98 - Filter calls to SVO database

### DIFF
--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -24,6 +24,8 @@ from astropy.table import Table
 from astroquery.svo_fps import SvoFps
 from jwst.pipeline import Detector1Pipeline, Image2Pipeline, Coron3Pipeline
 
+from .utils import get_filter_info
+
 import logging
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
@@ -33,40 +35,18 @@ log.setLevel(logging.INFO)
 # MAIN
 # =============================================================================
 
-# Load NIRCam, NIRISS, and MIRI filters from the SVO Filter Profile Service.
-# http://svo2.cab.inta-csic.es/theory/fps/
-wave_nircam = {}
-weff_nircam = {}
-filter_list = SvoFps.get_filter_list(facility='JWST', instrument='NIRCAM')
-for i in range(len(filter_list)):
-    name = filter_list['filterID'][i]
-    name = name[name.rfind('.') + 1:]
-    wave_nircam[name] = filter_list['WavelengthMean'][i] / 1e4  # micron
-    weff_nircam[name] = filter_list['WidthEff'][i] / 1e4  # micron
-wave_niriss = {}
-weff_niriss = {}
-filter_list = SvoFps.get_filter_list(facility='JWST', instrument='NIRISS')
-for i in range(len(filter_list)):
-    name = filter_list['filterID'][i]
-    name = name[name.rfind('.') + 1:]
-    wave_niriss[name] = filter_list['WavelengthMean'][i] / 1e4  # micron
-    weff_niriss[name] = filter_list['WidthEff'][i] / 1e4  # micron
-wave_miri = {}
-weff_miri = {}
-filter_list = SvoFps.get_filter_list(facility='JWST', instrument='MIRI')
-for i in range(len(filter_list)):
-    name = filter_list['filterID'][i]
-    name = name[name.rfind('.') + 1:]
-    wave_miri[name] = filter_list['WavelengthMean'][i] / 1e4  # micron
-    weff_miri[name] = filter_list['WidthEff'][i] / 1e4  # micron
-wave_miri['FND'] = 13.  # micron
-weff_miri['FND'] = 10.  # micron
-del filter_list
-
 # Initialize WebbPSF instruments.
+from webbpsf_ext.logging_utils import setup_logging
+setup_logging('WARN', verbose=False)
+
 nircam = webbpsf.NIRCam()
 niriss = webbpsf.NIRISS()
-miri = webbpsf.MIRI()
+miri   = webbpsf.MIRI()
+
+# Load NIRCam, NIRISS, and MIRI filters
+wave_nircam, weff_nircam, do_svo = get_filter_info('NIRCAM', return_more=True)
+wave_niriss, weff_niriss = get_filter_info('NIRISS', do_svo=do_svo)
+wave_miri,   weff_miri   = get_filter_info('MIRI',   do_svo=do_svo)
 
 class Database():
     """

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -557,6 +557,8 @@ def _get_tp_comsubst(instrume,
     """
     Get the COM substrate transmission averaged over the respective filter
     profile.
+
+    *** Deprecated - use `get_tp_comsubst` instead. ***
     
     Parameters
     ----------
@@ -574,6 +576,8 @@ def _get_tp_comsubst(instrume,
     
     """
     
+    log.warning('This function is deprecated. Use `get_tp_comsubst` instead.')
+
     # Default return.
     tp_comsubst = 1.
     

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -618,6 +618,9 @@ def get_tp_comsubst(instrume,
     """
     Get the COM substrate transmission averaged over the respective filter
     profile.
+
+    TODO: Spot check the COM throughput using photometric calibration data,
+    assuming there are stellar offsets on and off the COM substrate.
     
     Parameters
     ----------

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -607,3 +607,66 @@ def get_tp_comsubst(instrume,
     
     # Return.
     return tp_comsubst
+
+def get_filter_info(instrument, timeout=1, do_svo=True, return_more=False):
+    """ Load filter information from the SVO Filter Profile Service or webbpsf
+
+    Load NIRCam, NIRISS, and MIRI filters from the SVO Filter Profile Service.
+    http://svo2.cab.inta-csic.es/theory/fps/
+
+    If timeout to server, then use local copy of filter list and load through webbpsf.
+
+    Parameters
+    ----------
+    instrument : str
+        Name of instrument to load filter list for. 
+        Must be one of 'NIRCam', 'NIRISS', or 'MIRI'.
+    timeout : float
+        Timeout in seconds for connection to SVO Filter Profile Service.
+    do_svo : bool
+        If True, try to load filter list from SVO Filter Profile Service. 
+        If False, use webbpsf without first check web server.
+    return_more : bool
+        If True, also return `do_svo` variable, whether SVO was used or not.
+    """
+
+    from astroquery.svo_fps import SvoFps
+    import webbpsf
+
+    iname_upper = instrument.upper()
+
+    # Try to get filter list from SVO
+    if do_svo:
+        try:
+            filter_list = SvoFps.get_filter_list(facility='JWST', instrument=iname_upper, timeout=timeout)
+        except:
+            log.warning('Using SVO Filter Profile Service timed out. Using WebbPSF instead.')
+            do_svo = False
+
+    # If unsuccessful, use webbpsf to get filter list
+    if not do_svo:
+        inst_func = {
+            'NIRCAM': webbpsf.NIRCam,
+            'NIRISS': webbpsf.NIRISS,
+            'MIRI'  : webbpsf.MIRI,
+        }
+        inst = inst_func[iname_upper]()
+        filter_list = inst.filter_list
+
+    wave, weff = ({}, {})
+    if do_svo:
+        for i in range(len(filter_list)):
+            name = filter_list['filterID'][i]
+            name = name[name.rfind('.') + 1:]
+            wave[name] = filter_list['WavelengthMean'][i] / 1e4  # micron
+            weff[name] = filter_list['WidthEff'][i] / 1e4  # micron
+    else:
+        for filt in filter_list:
+            bp = inst._get_synphot_bandpass(filt)
+            wave[filt] = bp.avgwave().to_value('micron')
+            weff[filt] = bp.equivwidth().to_value('micron')
+
+    if return_more:
+        return wave, weff, do_svo
+    else:
+        return wave, weff


### PR DESCRIPTION
Part 2 of #98

This is a minor update for grabbing filter information during init:
- falls back to `webbpsf` filters if the SVO database cannot be reached. 

Rewrote COM throughput function:
- The `get_tp_comsubst` function now uses `webbpsf_ext`'s built-in bandpass functionality to recover COM transmission across a filter bandpass. The throughputs in `webbpsf_ext` have been corrected based on ISIM CV3 measurements. For the sake of consistency, I think it is better to use these instead of the older 2015 transmission file. 
