### PR TITLE
Part 4 of #98 - 1/f Noise Correction

### DIFF
--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -16,8 +16,13 @@ import astropy.io.fits as pyfits
 import matplotlib.pyplot as plt
 import numpy as np
 
-from jwst.datamodels import dqflags, RampModel
+from tqdm.auto import trange
+
+from jwst.lib import reffile_utils
+from jwst.datamodels import dqflags, RampModel, SaturationModel
 from jwst.pipeline import Detector1Pipeline, Image2Pipeline, Coron3Pipeline
+
+from webbpsf_ext import robust
 
 import logging
 log = logging.getLogger(__name__)
@@ -32,6 +37,21 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
     """
     The spaceKLIP JWST stage 1 pipeline class.
     
+    Apply all calibration steps to raw JWST ramps to produce 
+    a 2-D slope product. Custom sub-class of ``Detector1Pipeline`` 
+    with modifications for coronagraphic data.
+    
+    Included steps are: group_scale, dq_init, saturation, ipc, 
+    superbias, refpix, rscd, firstframe, lastframe, linearity, 
+    dark_current, reset, persistence, jump detection, ramp_fit, 
+    and gain_scale. 
+    """
+    
+    class_alias = "calwebb_coron1"
+
+    spec = """
+        remove_ktc         = boolean(default=True) # Remove kTC noise from data
+        remove_fnoise      = boolean(default=True) # Remove 1/f noise from data
     """
     
     def __init__(self,
@@ -100,6 +120,7 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
             input = self.run_step(self.rscd, input)
             input = self.run_step(self.dark_current, input)
             input = self.do_refpix(input)
+            input = self.run_step(self.jump, input)
         else:
             input = self.run_step(self.group_scale, input)
             input = self.run_step(self.dq_init, input)
@@ -110,7 +131,11 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
             input = self.run_step(self.linearity, input)
             input = self.run_step(self.persistence, input)
             input = self.run_step(self.dark_current, input)
-        input = self.run_step(self.jump, input)
+            input = self.run_step(self.jump, input)
+            if self.remove_ktc or self.remove_fnoise:
+                input = self.subtract_ktc(input)
+            if self.remove_fnoise:
+                input = self.subtract_fnoise(input, model_type='savgol')
         
         # Save calibrated ramp data.
         if self.ramp_fit.save_calibrated_ramp:
@@ -351,6 +376,168 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         res.pixeldq[nrow_off:nupper_off, -ncol_off - nright:nright_off] = res.pixeldq[nrow_off:nupper_off, -ncol_off - nright:nright_off] & ~dqflags.pixel['REFERENCE_PIXEL']
         
         return res
+
+    def _fit_slopes(self,
+                    input,
+                    sat_frac=0.5):
+        """Fit slopes to each integration
+        
+        Uses custom `cube_fit` function to fit slopes to each integration.
+        Returns aray of slopes and bias values for each integration.
+        Bias and slope arrays have shape (nints, ny, nx).
+
+        Parameters
+        ----------
+        input : jwst.datamodel
+            Input JWST datamodel housing the data to be fit.
+        sat_frac : float
+            Saturation threshold for fitting. Values above
+            this fraction of the saturation level are ignored.
+            Default is 0.5 to ensure that the fit is within 
+            the linear range.
+        """
+
+        from .imagetools import cube_fit
+
+        # Get saturation reference file
+        # Get the name of the saturation reference file
+        sat_name = self.saturation.get_reference_file(input, 'saturation')
+
+        # Open the reference file data model
+        sat_model = SaturationModel(sat_name)
+
+        # Extract subarray from saturation reference file, if necessary
+        if reffile_utils.ref_matches_sci(input, sat_model):
+            sat_thresh = sat_model.data.copy()
+        else:
+            ref_sub_model = reffile_utils.get_subarray_model(input, sat_model)
+            sat_thresh = ref_sub_model.data.copy()
+            ref_sub_model.close()
+
+        # Close the reference file
+        sat_model.close()
+
+        # Perform ramp fit to data to get bias offset
+        group_time = input.meta.exposure.group_time
+        ngroups = input.meta.exposure.ngroups
+        nints = input.meta.exposure.nints
+        tarr = np.arange(1, ngroups+1) * group_time
+        data = input.data
+
+        bias_arr = []
+        slope_arr = []
+        for i in range(nints):
+            # Get group-level bpmask for this integration
+            groupdq = input.groupdq[i]
+            # Make sure to accumulate the group-level dq mask
+            bpmask_arr = np.cumsum(groupdq, axis=0) > 0
+            cf = cube_fit(tarr, data[i], bpmask_arr=bpmask_arr,
+                          sat_vals=sat_thresh, sat_frac=sat_frac)
+            bias_arr.append(cf[0])
+            slope_arr.append(cf[1])
+        bias_arr = np.asarray(bias_arr)
+        slope_arr = np.asarray(slope_arr)
+
+        # bias and slope arrays have shape [nints, ny, nx]
+        # bias values are in units of DN and slope in DN/sec
+        return bias_arr, slope_arr
+
+    def subtract_ktc(self,
+                     input,
+                     sat_frac=0.5):
+        
+        bias_arr, _ = self._fit_slopes(input, sat_frac=sat_frac)
+
+        # Subtract bias from each integration
+        nints = input.meta.exposure.nints
+        for i in range(nints):
+            input.data[i] -= bias_arr[i]
+
+        return input
+    
+    def subtract_fnoise(self,
+                        input,
+                        sat_frac=0.5,
+                        **kwargs):
+        """Model and subtract 1/f noise from each integration
+        
+        TODO: Make this into a Step class.
+        TODO: Automatic function to determine if correction is necessary.
+
+        Parameters
+        ----------
+        input : jwst.datamodel
+            Input JWST datamodel to be processed.
+
+        Keyword Args
+        ------------
+        model_type : str
+            Must be 'median', 'mean', or 'savgol'. For 'mean' case,
+            it uses a robust mean that ignores outliers and NaNs.
+            The 'median' case uses `np.nanmedian`. The 'savgol' case
+            uses a Savitzky-Golay filter to model the 1/f noise, 
+            iteratively rejecting outliers from the model fit relative
+            to the median model. The default is 'savgol'.
+        """
+        
+        from .fnoise_clean import CleanSubarray
+
+        is_full_frame = 'FULL' in input.meta.subarray.name.upper()
+        nints    = input.meta.exposure.nints
+        ngroups  = input.meta.exposure.ngroups
+        noutputs = input.meta.exposure.noutputs
+
+        if is_full_frame:
+            assert noutputs == 4, 'Full frame data must have 4 outputs'
+        else:
+            assert noutputs == 1, 'Subarray data must have 1 output'
+
+        ny, nx = input.data.shape[-2:]
+        chsize = ny // noutputs
+
+        # Fit slopes to get signal mask
+        # Grab slopes if they've already been computed
+        _, slope_arr = self._fit_slopes(input, sat_frac=sat_frac)
+        slope_mean = robust.mean(slope_arr, axis=0)
+
+        # Generate a mean signal ramp to subtract from each group
+        group_time = input.meta.exposure.group_time
+        ngroups = input.meta.exposure.ngroups
+        tarr = np.arange(1, ngroups+1) * group_time
+        signal_mean_ramp = slope_mean * tarr.reshape([-1,1,1])
+
+        # Subtract 1/f noise from each integration
+        data = input.data
+        for i in trange(nints):
+            cube = data[i]
+            groupdq = input.groupdq[i]
+            # Cumulative sum of group DQ flags
+            bpmask_arr = np.cumsum(groupdq, axis=0) > 0
+            for j in range(ngroups):
+                # Exclude bad pixels
+                im_mask = ~bpmask_arr[j] #& mask
+                for ch in range(noutputs):
+                    # Get channel x-indices
+                    x1 = int(ch*chsize)
+                    x2 = int(x1 + chsize)
+
+                    # Channel subarrays
+                    imch = cube[j, :, x1:x2]
+                    sigch = signal_mean_ramp[j, :, x1:x2]
+                    good_mask = im_mask[:, x1:x2]
+
+                    # Remove averaged signal goup
+                    imch_diff = imch - sigch
+
+                    # Subtract 1/f noise
+                    nf_clean = CleanSubarray(imch_diff, good_mask)
+                    nf_clean.fit(**kwargs)
+                    # Subtract model from data
+                    data[i,j,:,x1:x2] -= nf_clean.model
+
+                    del nf_clean
+
+        return input
 
 def run_obs(database,
             steps={},

--- a/spaceKLIP/fnoise_clean.py
+++ b/spaceKLIP/fnoise_clean.py
@@ -1,0 +1,299 @@
+import os
+import numpy as np
+
+from webbpsf_ext import robust
+from scipy.signal import savgol_filter
+
+# class CleanFullFrame:
+
+class CleanSubarray:
+    """
+    CleanSubarray is the base class for removing residual correlated
+    read noise from generic JWST near-IR Subarray images.  It is
+    intended for use on Level 1 or 2 pipeline products on any type of
+    image product (group data, rateint, calint, rate, cal, etc). 
+    Suggest removing average signal levels from data and running
+    this on the residuals, which better reveal the 1/f noise structure.
+
+    Inspired by NSClean by Bernie Rauscher (https://arxiv.org/abs/2306.03250),
+    however instead of using FFTs and Matrix multiplication, this class uses
+    Savitzky-Golay filtering to model the 1/f noise and subtract it from the
+    data. This is much faster than the FFT approach and provides similar
+    results. 
+    """
+    
+    # Class variables. These are the same for all instances.
+    nloh = np.int32(12)       # New line overhead in pixels
+    tpix = np.float32(10.e-6) # Pixel dwell time in seconds
+    sigrej = np.float32(3.0)  # Standard deviation threshold for flagging
+                              #   statistical outliers.
+        
+    def __init__(self, data, mask, exclude_outliers=True):
+        """ 1/f noise modeling and subtraction for HAWAII-2RG subarrays.
+
+        This function assumes such that the slow-scan runs vertically along the
+        y-axis, while the fast scan direction runs horizontally. Direction 
+        (left to right or right to left) is irrelevant. 
+
+        Parameters
+        ==========
+        D : ndarray
+            Two-dimensional input data.
+        M : ndarray
+            Two dimensional background pixels mask. 
+            Pixels =True are modeled as background.
+            Pixels=False are excluded from the background model.
+        exclude_outliers : bool
+            Exclude statistical outliers and their nearest neighbors
+            from the background pixels mask.
+        """
+        from .utils import expand_mask
+
+        # Definitions
+        self.D = np.array(data, dtype=np.float32)
+        self.M = np.array(mask, dtype=np.bool_)
+        self.ny = np.int32(data.shape[0]) # Number of pixels in slow scan direction
+        self.nx = np.int32(data.shape[1]) # Number of pixels in fast scan direction
+        
+        # The mask potentially contains NaNs. Exclude them.
+        self.M[np.isnan(self.D)] = False
+        
+        # The mask potentially contains statistical outliers.
+        # Optionally exclude them.
+        if exclude_outliers is True:
+            gdpx = robust.mean(self.D, Cut=self.sigrej, return_mask=True)
+            bdpx = ~gdpx # Bad pixel mask
+            bdpx = expand_mask(bdpx, 1, grow_diagonal=False) # Also flag 4 nearest neighbors
+            gdpx = ~bdpx # Good pixel mask
+            self.M = self.M & gdpx
+
+        # Median subtract
+        self.D = self.D - np.nanmedian(self.D[self.M]) 
+
+    def fit(self, model_type='mean', **kwargs):
+        """ Return the model which is just median of each row
+        
+        Parameters
+        ==========
+        model_type : str
+            Must be 'median', 'mean', or 'savgol'. For 'mean' case,
+            it uses a robust mean that ignores outliers and NaNs.
+            The 'median' case uses `np.nanmedian`. The 'savgol' case
+            uses a Savitzky-Golay filter to model the 1/f noise, 
+            iteratively rejecting outliers from the model fit relative
+            to the median model. The default is 'savgol'.
+        """
+
+        # Fit the model
+        if 'median' in model_type:
+            self.model = self._fit_median(robust_mean=False)
+        elif 'mean' in model_type:
+            self.model = self._fit_median(robust_mean=True)
+        elif 'savgol' in model_type:
+            # Do savgol model
+            model_savgol = self._fit_savgol(**kwargs)
+
+            # Replace masked regions with median model
+            # model_mean = self._fit_median(robust_mean=True)
+            # model_savgol[~self.M] = model_mean[~self.M]
+
+            self.model = model_savgol
+        else:
+            raise ValueError(f"Do not recognize model_type={model_type}")
+
+    def _fit_median(self, robust_mean=False):
+        """ Return the model which is just median of each row
+        
+        Option to use robust mean instead of median.
+        """
+
+        mean_func = robust.mean if robust_mean else np.nanmedian
+
+        # Fit the model
+        data = self.D.copy()
+        data[~self.M] = np.nan
+        return mean_func(data, axis=1).repeat(self.nx).reshape(data.shape)
+        
+    def _fit_savgol(self, niter=5, **kwargs):
+        """ Use a Savitzky-Golay filter to smooth the masked row data
+
+        Parameters
+        ==========
+        niter : int
+            Number of iterations to use for rejecting outliers during
+            the model fit. If the number of rejected pixels does not
+            change between iterations, then the fit is considered
+            converged and the loop is broken.
+
+        Keyword Args
+        ============
+        winsize : int
+            Size of the window filter. Should be an odd number.
+        order : int
+            Order of the polynomial used to fit the samples.
+        per_line : bool
+            Smooth each channel line separately with the hopes of avoiding
+            edge discontinuities.
+        mask : bool image or None
+            An image mask of pixels to ignore. Should be same size as im_arr.
+            This can be used to mask pixels that the filter should ignore, 
+            such as stellar sources or pixel outliers. A value of True indicates
+            that pixel should be ignored.
+        mode : str
+            Must be 'mirror', 'constant', 'nearest', 'wrap' or 'interp'.  This
+            determines the type of extension to use for the padded signal to
+            which the filter is applied.  When `mode` is 'constant', the padding
+            value is given by `cval`. 
+            When the 'interp' mode is selected (the default), no extension
+            is used.  Instead, a degree `polyorder` polynomial is fit to the
+            last `window_length` values of the edges, and this polynomial is
+            used to evaluate the last `window_length // 2` output values.
+        cval : float
+            Value to fill past the edges of the input if `mode` is 'constant'.
+            Default is 0.0.
+        """
+
+        bpmask = ~self.M # Bad pixel mask
+        model = channel_smooth_savgol(self.D, mask=bpmask, **kwargs)
+
+        for i in range(niter):
+            # Get median model
+            model_med = self._fit_median(robust_mean=False)
+
+            # Find standard deviation of difference between model and median values
+            bpmask = ~self.M 
+            diff = model - model_med
+            diff[bpmask] = np.nan
+            sig = np.nanstd(diff, ddof=1)
+
+            # Flag new outliers
+            bp_sig = np.abs(diff) > 3*sig
+            bpmask_new = bpmask | bp_sig
+            if bpmask_new.sum() == bpmask.sum():
+                break
+
+            # Update mask and refit model
+            self.M = ~bpmask_new
+            model = channel_smooth_savgol(self.D, mask=bpmask_new, **kwargs)
+
+        return model
+        
+    def clean(self, weight_fit=True):
+        """
+        Clean the data
+        
+        Parameters: weight_fit:bool
+                      Use weighted least squares as described in the NSClean paper.
+                      Otherwise, it is a simple unweighted fit.
+
+        """ 
+        self.fit(weight_fit=weight_fit)           # Fit the background model
+        self.D -= self.model # Overwrite data with cleaned data
+        return(self.D)
+
+def mask_helper():
+    """Helper to handle indices and logical indices of a mask
+
+    Output: index, a function, with signature indices = index(logical_indices),
+    to convert logical indices of a mask to 'equivalent' indices
+
+    Example:
+        >>> # linear interpolation of NaNs
+        >>> mask = np.isnan(y)
+        >>> x = mask_helper(y)
+        >>> y[mask]= np.interp(x(mask), x(~mask), y[~mask])
+    """
+    return lambda z: np.nonzero(z)[0]
+
+def channel_smooth_savgol(im_arr, winsize=127, order=3, per_line=False, 
+    mask=None, **kwargs):
+    """Channel smoothing using savgol filter
+
+    Function for generating a map of the 1/f noise within a series of input images.
+
+    Parameters
+    ==========
+    im_arr : ndarray
+        Input array of images (intended to be a cube of output channels).
+        Shape should either be (ny, chsize) to smooth a single channel or
+        (nchan, ny, chsize) for  multiple channels.
+        Each image is operated on separately. If only two dimensions,
+        then only a single input image is assumed. NaN's will be
+        interpolated over.
+
+    Keyword Args
+    ============
+    winsize : int
+        Size of the window filter. Should be an odd number.
+    order : int
+        Order of the polynomial used to fit the samples.
+    per_line : bool
+        Smooth each channel line separately with the hopes of avoiding
+        edge discontinuities.
+    mask : bool image or None
+        An image mask of pixels to ignore. Should be same size as im_arr.
+        This can be used to mask pixels that the filter should ignore, 
+        such as stellar sources or pixel outliers. A value of True indicates
+        that pixel should be ignored.
+    mode : str
+        Must be 'mirror', 'constant', 'nearest', 'wrap' or 'interp'.  This
+        determines the type of extension to use for the padded signal to
+        which the filter is applied.  When `mode` is 'constant', the padding
+        value is given by `cval`. 
+        When the 'interp' mode is selected (the default), no extension
+        is used.  Instead, a degree `polyorder` polynomial is fit to the
+        last `window_length` values of the edges, and this polynomial is
+        used to evaluate the last `window_length // 2` output values.
+    cval : float
+        Value to fill past the edges of the input if `mode` is 'constant'.
+        Default is 0.0.
+    """
+
+    sh = im_arr.shape
+    if len(sh)==2:
+        nz = 1
+        ny, nx = sh
+    else:
+        nz, ny, nx = sh
+
+    # Check that winsize is odd
+    winsize = winsize-1 if winsize % 2 == 0 else winsize
+
+    # Reshape in case of nz=1
+    im_arr = im_arr.reshape([nz, -1])
+    if mask is not None:
+        mask = mask.reshape([nz, -1])
+
+    res_arr = []
+    for i, im in enumerate(im_arr):
+        # im should be a 1D array
+
+        # Interpolate over masked data and NaN's
+        nans = np.isnan(im)
+        im_mask = nans if mask is None else nans | mask[i].flatten()
+        if im_mask.any():
+            # Create a copy so as to not change the original data
+            im = np.copy(im)
+
+            # Use a savgol filter to smooth out any outliers
+            res = im.copy()
+            res[~im_mask] = savgol_filter(im[~im_mask], 33, 3, mode='interp')
+
+            # Replace masked pixels with linear interpolation
+            x = mask_helper() # Returns the nonzero (True) indices of a mask
+            im[im_mask]= np.interp(x(im_mask), x(~im_mask), res[~im_mask])
+
+        if per_line:
+            im = im.reshape([ny,-1])
+
+            res = savgol_filter(im, winsize, order, axis=1, delta=1, **kwargs)
+            res_arr.append(res)
+        else:
+            res = savgol_filter(im, winsize, order, delta=1, **kwargs)
+            res_arr.append(res.reshape([ny,-1]))
+    res_arr = np.asarray(res_arr)
+
+    if len(sh)==2:
+        return res_arr[0]
+    else:
+        return res_arr

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -2078,3 +2078,148 @@ class ImageTools():
                 plt.savefig(output_file)
                 log.info(f" Plot saved in {output_file}")
                 plt.close()
+
+def cube_fit(tarr, data, sat_vals, sat_frac=0.95, bias=None, 
+             deg=1, bpmask_arr=None, fit_zero=False, verbose=False,
+             use_legendre=False, lxmap=None, return_lxmap=False,
+             return_chired=False):
+    """Fit unsaturated data and return coefficients"""
+        
+    from webbpsf_ext.maths import jl_poly_fit, jl_poly
+
+    nz, ny, nx = data.shape
+    
+    # Subtract bias?
+    imarr = data if bias is None else data - bias
+        
+    # Array of masked pixels (saturated)
+    mask_good = imarr < sat_frac*sat_vals
+    if bpmask_arr is not None:
+        mask_good = mask_good & ~bpmask_arr
+    
+    # Reshape for all pixels in single dimension
+    imarr = imarr.reshape([nz, -1])
+    mask_good = mask_good.reshape([nz, -1])
+
+    # Initial 
+    cf = np.zeros([deg+1, nx*ny])
+    if return_lxmap:
+        lx_min = np.zeros([nx*ny])
+        lx_max = np.zeros([nx*ny])
+    if return_chired:
+        chired = np.zeros([nx*ny])
+
+    # For each 
+    npix_sum = 0
+    i0 = 0 if fit_zero else 1
+    for i in np.arange(i0,nz)[::-1]:
+        ind = (cf[1] == 0) & (mask_good[i])
+        npix = np.sum(ind)
+        npix_sum += npix
+        
+        if verbose:
+            print(i+1,npix,npix_sum, 'Remaining: {}'.format(nx*ny-npix_sum))
+            
+        if npix>0:
+            if fit_zero:
+                x = np.concatenate(([0], tarr[0:i+1]))
+                y = np.concatenate((np.zeros([1, np.sum(ind)]), imarr[0:i+1,ind]), axis=0)
+            else:
+                x, y = (tarr[0:i+1], imarr[0:i+1,ind])
+
+            if return_lxmap:
+                lx_min[ind] = np.min(x) if lxmap is None else lxmap[0]
+                lx_max[ind] = np.max(x) if lxmap is None else lxmap[1]
+                
+            # Fit line if too few points relative to polynomial degree
+            if len(x) <= deg+1:
+                cf[0:2,ind] = jl_poly_fit(x,y, deg=1, use_legendre=use_legendre, lxmap=lxmap)
+            else:
+                cf[:,ind] = jl_poly_fit(x,y, deg=deg, use_legendre=use_legendre, lxmap=lxmap)
+
+            # Get reduced chi-sqr metric for poorly fit data
+            if return_chired:
+                yfit = jl_poly(x, cf[:,ind])
+                deg_chi = 1 if len(x)<=deg+1 else deg
+                dof = y.shape[0] - deg_chi
+                chired[ind] = chisqr_red(y, yfit=yfit, dof=dof)
+
+    imarr = imarr.reshape([nz,ny,nx])
+    mask_good = mask_good.reshape([nz,ny,nx])
+    
+    cf = cf.reshape([deg+1,ny,nx])
+    if return_lxmap:
+        lxmap_arr = np.array([lx_min, lx_max]).reshape([2,ny,nx])
+        if return_chired:
+            chired = chired.reshape([ny,nx])
+            return cf, lxmap_arr, chired
+        else:
+            return cf, lxmap_arr
+    else:
+        if return_chired:
+            chired = chired.reshape([ny,nx])
+            return cf, chired
+        else:
+            return cf
+        
+def chisqr_red(yvals, yfit=None, err=None, dof=None,
+               err_func=np.std):
+    """ Calculate reduced chi square metric
+    
+    If yfit is None, then yvals assumed to be residuals.
+    In this case, `err` should be specified.
+    
+    Parameters
+    ==========
+    yvals : ndarray
+        Sampled values.
+    yfit : ndarray
+        Model fit corresponding to `yvals`.
+    dof : int
+        Number of degrees of freedom (nvals - nparams - 1).
+    err : ndarray or float
+        Uncertainties associated with `yvals`. If not specified,
+        then use yvals point-to-point differences to estimate
+        a single value for the uncertainty.
+    err_func : func
+        Error function uses to estimate `err`.
+    """
+    
+    if (yfit is None) and (err is None):
+        print("Both yfit and err cannot be set to None.")
+        return
+    
+    diff = yvals if yfit is None else yvals - yfit
+    
+    sh_orig = diff.shape
+    ndim = len(sh_orig)
+    if ndim==1:
+        if err is None:
+            err = err_func(yvals[1:] - yvals[0:-1]) / np.sqrt(2)
+        dev = diff / err
+        chi_tot = np.sum(dev**2)
+        dof = len(chi_tot) if dof is None else dof
+        chi_red = chi_tot / dof
+        return chi_red
+    
+    # Convert to 2D array
+    if ndim==3:
+        sh_new = [sh_orig[0], -1]
+        diff = diff.reshape(sh_new)
+        yvals = yvals.reshape(sh_new)
+        
+    # Calculate errors for each element
+    if err is None:
+        err_arr = np.array([yvals[i+1] - yvals[i] for i in range(sh_orig[0]-1)])
+        err = err_func(err_arr, axis=0) / np.sqrt(2)
+        del err_arr
+    else:
+        err = err.reshape(diff.shape)
+    # Get reduced chi sqr for each element
+    dof = sh_orig[0] if dof is None else dof
+    chi_red = np.sum((diff / err)**2, axis=0) / dof
+    
+    if ndim==3:
+        chi_red = chi_red.reshape(sh_orig[-2:])
+        
+    return chi_red


### PR DESCRIPTION
Part 4 of #98

Correct 1/f noise striping in stage1:
- Create fnoise_clean.py file that houses code for fitting a 1/f noise model to data and iteratively masks outlier pixels.
- Add `cube_fit` function, which utilizes polynomial fitting routines from `webbpsf_ext` to fit linearized unsaturated and unflagged pixel data to quickly generate a kTC bias and slope images.
- Utilize `cube_fit` to create kTC bias to subtract from linearized ramp data to create clean group-level data
- The slope images from `cube_fit` are then averaged together and used to produce a high-SNR ramp such that group signal levels match those within a given integration. 
- Use 1/f noise filtering algorithm on group level data to model the spatial 1/f striping and subtract it. 

1/f cleaning routine adds about 100 msec for a single 320x320 frame. Expect time to increase proportional to frame size. See issue #97 and `fnoise.py` for more details.

See issue #97 for more information on operations.

Before and after 1/f noise correction for four integrations in PID 1386 Obs 116:
![image](https://github.com/kammerje/spaceKLIP/assets/17557291/44d95d83-42d5-4696-9738-3707c7f72d35)