### PR TITLE
Part 5 of #98 - Updates to stage2 pipeline calls

### DIFF
--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -83,16 +83,18 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         # Initialize reference pixel correction parameters
         self.refpix.nlower = 4
         self.refpix.nupper = 4
-        self.refpix.nleft = 4
-        self.refpix.nright = 4
         self.refpix.nrow_off = 0
+        # NOTE: nleft, right, and ncol_off don't actually do anything.
+        #   For 1/f noise correction, set the `remove_fnoise` attribute to True
+        #   to model and subtract the 1/f noise.
+        self.refpix.nleft = 0
+        self.refpix.nright = 0
         self.refpix.ncol_off = 0
 
         # Ramp fit saving options
         # NOTE: `save_calibrated_ramp` is already a Detector1Pipeline property
         self.ramp_fit.save_calibrated_ramp = False
         
-        pass
     
     def process(self,
                 input):
@@ -706,12 +708,6 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
         - refpix/nupper : int, optional
             Number of rows at frame top that shall be used as additional
             reference pixels. The default is 0.
-        - refpix/nleft : int, optional
-            Number of rows at frame left side that shall be used as additional
-            reference pixels. The default is 0.
-        - refpix/nright : int, optional
-            Number of rows at frame right side that shall be used as additional
-            reference pixels. The default is 0.
         - ramp_fit/save_calibrated_ramp : bool, optional
             Save the calibrated ramp? The default is False.
 
@@ -815,10 +811,7 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
         nl = nr = 4
     pipeline.refpix.nlower   = kwargs.get('nlower', nb)
     pipeline.refpix.nupper   = kwargs.get('nupper', nt)
-    pipeline.refpix.nleft    = kwargs.get('nleft',  nl)
-    pipeline.refpix.nright   = kwargs.get('nright', nr)
     pipeline.refpix.nrow_off = kwargs.get('nrow_off', 0)
-    pipeline.refpix.ncol_off = kwargs.get('ncol_off', 0)
 
     # Set some Step parameters
     pipeline.jump.rejection_threshold              = kwargs.get('rejection_threshold', 4)
@@ -879,13 +872,11 @@ def run_obs(database,
       step, and unflag the pseudo reference pixels again. Only applicable for
       subarray data.
     - Remove horizontal 1/f noise spatial striping in NIRCam data.
-
     
     Parameters
     ----------
     database : spaceKLIP.Database
-        SpaceKLIP database on which the JWST stage 1 detector pipeline shall be
-        run.
+        SpaceKLIP database on which the JWST stage 1 pipeline shall be run.
     steps : dict, optional
         See here for how to use the steps parameter:
         https://jwst-pipeline.readthedocs.io/en/latest/jwst/user_documentation/running_pipeline_python.html#configuring-a-pipeline-step-in-python
@@ -900,12 +891,6 @@ def run_obs(database,
             reference pixels. The default is 0.
         - refpix/nupper : int, optional
             Number of rows at frame top that shall be used as additional
-            reference pixels. The default is 0.
-        - refpix/nleft : int, optional
-            Number of rows at frame left side that shall be used as additional
-            reference pixels. The default is 0.
-        - refpix/nright : int, optional
-            Number of rows at frame right side that shall be used as additional
             reference pixels. The default is 0.
         - ramp_fit/save_calibrated_ramp : bool, optional
             Save the calibrated ramp? The default is False.

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -756,8 +756,9 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     skip_jump : bool, optional
         Skip jump detection step? Default: False.
     skip_dark : bool, optional
-        Skip dark current subtraction step? Default: True.
-        Dark current cal files are really low SNR.
+        Skip dark current subtraction step? Default is True for 
+        subarrays and False for full frame data.
+        Dark current cal files for subarrays are really low SNR.
     skip_ipc : bool, optional
         Skip IPC correction step? Default: True.
     skip_persistence : bool, optional

--- a/spaceKLIP/plotting.py
+++ b/spaceKLIP/plotting.py
@@ -205,7 +205,7 @@ def display_coron_image(filename):
 
         model = modeltype(filename)  # cubemodel needed for rateints
         
-        if cube:
+        if cube_ints:
             image = np.nanmean(model.data, axis=0)
             dq = model.dq[0]
             nints = model.meta.nints
@@ -664,6 +664,8 @@ def plot_subimages(imgdirs, subdirs, filts, submodes, numKL,
     imtext_col: str
         Color of any text / arrows that go on top of the images
     '''
+
+    from matplotlib.ticker import MultipleLocator, MaxNLocator
 
     # Get the files we care about
     imgfiles = sorted(list(chain.from_iterable([glob.glob(imgdir+'*.fits') for imgdir in imgdirs])))


### PR DESCRIPTION
Changes to `runobs`:
- Calls `run_single_file` similar to those in #99 
- Added various verbosity options for those who dislike the deluge of log outputs
  - `verbose` keyword set to True shows everything at INFO level or above from the pipeline. Setting this to False will show various SpaceKLIP log messages, but suppress pipeline message below ERROR.
  - `quiet` suppresses all messages below ERROR and employs progress bars to keep track of data reduction progress.
  - Skip pipeline processing if data results already exist in output directory rather than re-running unnecessary and overwriting. Can be overriden using the `overwrite` keyword.
  - Add option to also process rate->cal in addition to the rateints data products.

Miscellaneous
- If outlier detection was run but intermediates were not request to be saved, remove the intermediate _median.fits files.
- fixed some random undefined variables in plottying.py