### PR TITLE
update readthe docs config 

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,7 +5,9 @@ sphinx:
   configuration: docs/source/conf.py
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
 
 python:
   version: 3.8


### PR DESCRIPTION
Minor but required update as per https://blog.readthedocs.com/use-build-os-config/






For the record here's a copy of the auto notification email I got from RTD. (Does anyone other than me get the RTD emails for this package, by the way? ) 


<blockquote>

Hello,
The build.image config key on .readthedocs.yaml has been deprecated, and will be removed on October 16, 2023. We are sending weekly notifications about this issue to all impacted users, as well as temporary build failures (brownouts) as the date approaches for those who haven't migrated their projects. The timeline for this deprecation is as follows:
* Monday, August 28, 2023: Do the first brownout (temporarily enforce this deprecation) for 12 hours: 00:01 PST to 11:59 PST (noon)
* Monday, September 18, 2023: Do a second brownout (temporarily enforce this deprecation) for 24 hours: 00:01 PST to 23:59 PST (midnight)
* Monday, October 2, 2023: Do a third and final brownout (temporarily enforce this deprecation) for 48 hours: 00:01 PST to October 3, 2023 23:59 PST (midnight)
* Monday, October 16, 2023: Fully remove support for building documentation using "build.image" on the configuration file

We have identified that the following projects which you maintain, and were built in the last year, are impacted by this deprecation:
* [spaceklip](https://urldefense.com/v3/__https://readthedocs.org/projects/spaceklip/__;!!CrWY41Z8OgsX0i-WU-0LuAcUu2o!zV-Sm8pBmabvLIX7NyD7XBacH1_RQCylS6QcAqgvhTIAySum-EdSHn7Gx9eXPnqVwrDnBSPAM_41hJhpqYDW$)

Please use build.os on your configuration file to ensure that they continue building successfully and to stop receiving these notifications. If you want to opt-out from these emails, you can [edit your preferences in your account settings](https://urldefense.com/v3/__https://readthedocs.org/accounts/edit/__;!!CrWY41Z8OgsX0i-WU-0LuAcUu2o!zV-Sm8pBmabvLIX7NyD7XBacH1_RQCylS6QcAqgvhTIAySum-EdSHn7Gx9eXPnqVwrDnBSPAM_41hD9XqTMe$). For more information on how to use build.os, [read our blog post](https://urldefense.com/v3/__https://blog.readthedocs.com/use-build-os-config/__;!!CrWY41Z8OgsX0i-WU-0LuAcUu2o!zV-Sm8pBmabvLIX7NyD7XBacH1_RQCylS6QcAqgvhTIAySum-EdSHn7Gx9eXPnqVwrDnBSPAM_41hEYYnN7o$) Get in touch with us [via our support](https://urldefense.com/v3/__https://readthedocs.org/support/__;!!CrWY41Z8OgsX0i-WU-0LuAcUu2o!zV-Sm8pBmabvLIX7NyD7XBacH1_RQCylS6QcAqgvhTIAySum-EdSHn7Gx9eXPnqVwrDnBSPAM_41hCrthAA5$) and let us know if you are unable to use a configuration file for any reason.
Keep documenting,
Read the Docs

</blockquote>