### PR TITLE
Create 1/f noise correction Step class

### DIFF
--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -21,6 +21,7 @@ from tqdm.auto import trange
 from jwst.lib import reffile_utils
 from jwst.datamodels import dqflags, RampModel, SaturationModel
 from jwst.pipeline import Detector1Pipeline, Image2Pipeline, Coron3Pipeline
+from .fnoise_clean import kTCSubtractStep, OneOverfStep
 
 from webbpsf_ext import robust
 
@@ -53,9 +54,6 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         save_intermediates = boolean(default=False) # Save all intermediate step results
         rate_int_outliers  = boolean(default=False) # Flag outlier pixels in rateints
         return_rateints    = boolean(default=False) # Return rateints or rate product?
-        remove_ktc         = boolean(default=True) # Remove kTC noise from data
-        remove_fnoise      = boolean(default=True) # Remove 1/f noise from data
-        remove_fnoise_horiz= boolean(default=True) # Remove horizontal striping from data
     """
     
     def __init__(self,
@@ -73,6 +71,9 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         None.
         
         """
+
+        self.step_defs['subtract_ktc'] = kTCSubtractStep
+        self.step_defs['subtract_1overf'] = OneOverfStep
         
         # Initialize Detector1Pipeline class.
         super(Coron1Pipeline_spaceKLIP, self).__init__(**kwargs)
@@ -86,8 +87,8 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         self.refpix.nupper = 4
         self.refpix.nrow_off = 0
         # NOTE: nleft, right, and ncol_off don't actually do anything.
-        #   For 1/f noise correction, set the `remove_fnoise` attribute to True
-        #   to model and subtract the 1/f noise.
+        #   For 1/f noise correction, use the `subtract_1overf` Step
+        #   to model and subtract the 1/f noise. On by default.
         self.refpix.nleft = 0
         self.refpix.nright = 0
         self.refpix.ncol_off = 0
@@ -134,6 +135,7 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
             input = self.do_refpix(input)
             input = self.run_step(self.charge_migration, input)
             input = self.run_step(self.jump, input)
+            # TODO: Include same / similar subtract_1overf step???
         else:
             input = self.run_step(self.group_scale, input)
             input = self.run_step(self.dq_init, input)
@@ -146,10 +148,8 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
             input = self.run_step(self.dark_current, input)
             input = self.run_step(self.charge_migration, input)
             input = self.run_step(self.jump, input)
-            if self.remove_ktc or self.remove_fnoise:
-                input = self.subtract_ktc(input)
-            if self.remove_fnoise:
-                input = self.subtract_fnoise(input, model_type='savgol')
+            input = self.run_step(self.subtract_ktc, input)
+            input = self.run_step(self.subtract_1overf, input)
         
         # save the corrected ramp data, if requested
         if self.ramp_fit.save_calibrated_ramp or self.save_calibrated_ramp or self.save_intermediates:
@@ -355,10 +355,10 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
         ------------
         sigma_cut : float
             Sigma cut for outlier detection.
-            Default is 5.
+            Default is 10.
         nint_min : int
             Minimum number of integrations required for outlier detection.
-            Default is 5.
+            Default is 10.
         """
         from .utils import cube_outlier_detection
 
@@ -510,177 +510,6 @@ class Coron1Pipeline_spaceKLIP(Detector1Pipeline):
 
         return res
 
-    def _fit_slopes(self,
-                    input,
-                    sat_frac=0.5):
-        """Fit slopes to each integration
-        
-        Uses custom `cube_fit` function to fit slopes to each integration.
-        Returns aray of slopes and bias values for each integration.
-        Bias and slope arrays have shape (nints, ny, nx).
-
-        Parameters
-        ----------
-        input : jwst.datamodel
-            Input JWST datamodel housing the data to be fit.
-        sat_frac : float
-            Saturation threshold for fitting. Values above
-            this fraction of the saturation level are ignored.
-            Default is 0.5 to ensure that the fit is within 
-            the linear range.
-        """
-        from .utils import cube_fit
-
-        # Get saturation reference file
-        # Get the name of the saturation reference file
-        sat_name = self.saturation.get_reference_file(input, 'saturation')
-
-        # Open the reference file data model
-        sat_model = SaturationModel(sat_name)
-
-        # Extract subarray from saturation reference file, if necessary
-        if reffile_utils.ref_matches_sci(input, sat_model):
-            sat_thresh = sat_model.data.copy()
-        else:
-            ref_sub_model = reffile_utils.get_subarray_model(input, sat_model)
-            sat_thresh = ref_sub_model.data.copy()
-            ref_sub_model.close()
-
-        # Close the reference file
-        sat_model.close()
-
-        # Perform ramp fit to data to get bias offset
-        group_time = input.meta.exposure.group_time
-        ngroups = input.meta.exposure.ngroups
-        nints = input.meta.exposure.nints
-        tarr = np.arange(1, ngroups+1) * group_time
-        data = input.data
-
-        bias_arr = []
-        slope_arr = []
-        for i in range(nints):
-            # Get group-level bpmask for this integration
-            groupdq = input.groupdq[i]
-            # Make sure to accumulate the group-level dq mask
-            bpmask_arr = np.cumsum(groupdq, axis=0) > 0
-            cf = cube_fit(tarr, data[i], bpmask_arr=bpmask_arr,
-                          sat_vals=sat_thresh, sat_frac=sat_frac)
-            bias_arr.append(cf[0])
-            slope_arr.append(cf[1])
-        bias_arr = np.asarray(bias_arr)
-        slope_arr = np.asarray(slope_arr)
-
-        # bias and slope arrays have shape [nints, ny, nx]
-        # bias values are in units of DN and slope in DN/sec
-        return bias_arr, slope_arr
-
-    def subtract_ktc(self,
-                     input,
-                     sat_frac=0.5):
-        
-        bias_arr, _ = self._fit_slopes(input, sat_frac=sat_frac)
-
-        # Subtract bias from each integration
-        nints = input.meta.exposure.nints
-        for i in range(nints):
-            input.data[i] -= bias_arr[i]
-
-        return input
-    
-    def subtract_fnoise(self,
-                        input,
-                        sat_frac=0.5,
-                        **kwargs):
-        """Model and subtract 1/f noise from each integration
-        
-        TODO: Make this into a Step class.
-        TODO: Automatic function to determine if correction is necessary.
-
-        Parameters
-        ----------
-        input : jwst.datamodel
-            Input JWST datamodel to be processed.
-
-        Keyword Args
-        ------------
-        model_type : str
-            Must be 'median', 'mean', or 'savgol'. For 'mean' case,
-            it uses a robust mean that ignores outliers and NaNs.
-            The 'median' case uses `np.nanmedian`. The 'savgol' case
-            uses a Savitzky-Golay filter to model the 1/f noise, 
-            iteratively rejecting outliers from the model fit relative
-            to the median model. The default is 'savgol'.
-        """
-        from .fnoise_clean import CleanSubarray
-
-        is_full_frame = 'FULL' in input.meta.subarray.name.upper()
-        nints    = input.meta.exposure.nints
-        ngroups  = input.meta.exposure.ngroups
-        noutputs = input.meta.exposure.noutputs
-
-        if is_full_frame:
-            assert noutputs == 4, 'Full frame data must have 4 outputs'
-        else:
-            assert noutputs == 1, 'Subarray data must have 1 output'
-
-        ny, nx = input.data.shape[-2:]
-        chsize = ny // noutputs
-
-        # Fit slopes to get signal mask
-        # Grab slopes if they've already been computed
-        _, slope_arr = self._fit_slopes(input, sat_frac=sat_frac)
-        slope_mean = robust.mean(slope_arr, axis=0)
-
-        # Generate a mean signal ramp to subtract from each group
-        group_time = input.meta.exposure.group_time
-        ngroups = input.meta.exposure.ngroups
-        tarr = np.arange(1, ngroups+1) * group_time
-        signal_mean_ramp = slope_mean * tarr.reshape([-1,1,1])
-
-        # Subtract 1/f noise from each integration
-        data = input.data
-        for i in trange(nints):
-            cube = data[i]
-            groupdq = input.groupdq[i]
-            # Cumulative sum of group DQ flags
-            bpmask_arr = np.cumsum(groupdq, axis=0) > 0
-            for j in range(ngroups):
-                # Exclude bad pixels
-                im_mask = ~bpmask_arr[j] #& mask
-                for ch in range(noutputs):
-                    # Get channel x-indices
-                    x1 = int(ch*chsize)
-                    x2 = int(x1 + chsize)
-
-                    # Channel subarrays
-                    imch = cube[j, :, x1:x2]
-                    sigch = signal_mean_ramp[j, :, x1:x2]
-                    good_mask = im_mask[:, x1:x2]
-
-                    # Remove averaged signal goup
-                    imch_diff = imch - sigch
-
-                    # Subtract 1/f noise
-                    nf_clean = CleanSubarray(imch_diff, good_mask)
-                    nf_clean.fit(**kwargs)
-                    # Subtract model from data
-                    data[i,j,:,x1:x2] -= nf_clean.model
-                    del nf_clean
-
-                    # And do the same horizontally
-                    if self.remove_fnoise_horiz:
-                        imch_diff = data[i,j,:,x1:x2] - sigch
-                        imch_diff_rot = np.rot90(imch_diff, k=1, axes=(1,0))
-                        good_mask_rot = np.rot90(good_mask, k=1, axes=(1,0))
-                        nf_clean = CleanSubarray(imch_diff_rot, good_mask_rot)
-                        nf_clean.fit(**kwargs)
-                        model_derot = np.rot90(nf_clean.model, k=-1, axes=(1,0))
-                        # Subtract model from data
-                        data[i,j,:,x1:x2] -= model_derot
-                        del nf_clean
-
-        return input
-
 def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     """ Run the JWST stage 1 detector pipeline on a single file.
     
@@ -709,13 +538,16 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
             Flag also diagonal pixels (or only bottom/top/left/right)? 
             The default is True.
         - saturation/flag_rcsat : bool, optional
-            Flag RC pixels as saturated? The default is False.
+            Flag RC pixels as always saturated? The default is False.
         - refpix/nlower : int, optional
             Number of rows at frame bottom that shall be used as additional
-            reference pixels. The default is 0.
+            reference pixels. The default is 4.
         - refpix/nupper : int, optional
             Number of rows at frame top that shall be used as additional
-            reference pixels. The default is 0.
+            reference pixels. The default is 4.
+        - refpix/nrow_off : int, optional
+            Number of rows to offset the reference pixel region from the
+            bottom/top of the frame. The default is 0.
         - ramp_fit/save_calibrated_ramp : bool, optional
             Save the calibrated ramp? The default is False.
 
@@ -749,14 +581,14 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
         Flag outlier pixels in rateints? Default is False.
         Uses the `cube_outlier_detection` function and requires
         a minimum of 5 integrations.
-    remove_ktc : bool, optional
+    flag_rcsat : bool, optional
+        Flag known RC pixels as always saturated? Default is False.
+    skip_ktc : bool, optional
         Remove kTC noise by fitting ramp data to get bias? 
-        Default is True.
-    remove_fnoise : bool, optional
-        Remove 1/f noise from data at group level? 
-        Default is True.
-    remove_fnoise_horiz : bool, optional
-        Remove striping noise from data in horizontal direction?
+        Useful for looking at linearized ramp data.
+        Default: False.
+    skip_fnoise : bool, optional
+        Skip 1/f noise removal? Default: False.
     skip_charge : bool, optional
         Skip charge migration flagging step? Default: False.
     skip_jump : bool, optional
@@ -802,12 +634,15 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     pipeline.jump.skip             = kwargs.get('skip_jump', False)
     pipeline.ipc.skip              = kwargs.get('skip_ipc', False)
     pipeline.persistence.skip      = kwargs.get('skip_persistence', False)
+    pipeline.subtract_ktc.skip     = kwargs.get('skip_ktc', False)
+    pipeline.subtract_1overf.skip  = kwargs.get('skip_fnoise', False)
+
     # Skip dark current for subarray by default, but not full frame
     skip_dark     = kwargs.get('skip_dark', None)
     if skip_dark is None:
         hdr0 = pyfits.getheader(fitspath, ext=0)
         is_full_frame = 'FULL' in hdr0['SUBARRAY']
-        skip_dark = not is_full_frame  # False if full frame, otherwise True
+        skip_dark = False if is_full_frame else True
     pipeline.dark_current.skip = skip_dark
 
     # Determine reference pixel correction parameters based on
@@ -818,7 +653,7 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
         nb, nt, nl, nr = nrc_ref_info(hdr0['APERNAME'], orientation='sci')
     else:
         nb, nt, nl, nr = (0, 0, 0, 0)
-    # If everything is 0, set to defult to 4 around the edges
+    # If everything is 0, set to default to 4 around the edges
     if nb + nt == 0:
         nb = nt = 4
     if nl + nr == 0:
@@ -837,9 +672,9 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     pipeline.rate_int_outliers         = kwargs.get('rate_int_outliers', False)
 
     # 1/f noise correction
-    pipeline.remove_ktc          = kwargs.get('remove_ktc', True)
-    pipeline.remove_fnoise       = kwargs.get('remove_fnoise', True)
-    pipeline.remove_fnoise_horiz = kwargs.get('remove_fnoise_horiz', True)
+    # pipeline.remove_ktc          = kwargs.get('remove_ktc', True)
+    # pipeline.remove_fnoise       = kwargs.get('remove_fnoise', True)
+    # pipeline.remove_fnoise_horiz = kwargs.get('remove_fnoise_horiz', True)
 
     # Skip pixels with only 1 group in ramp_fit?
     pipeline.ramp_fit.suppress_one_group = kwargs.get('suppress_one_group', False)
@@ -900,15 +735,19 @@ def run_obs(database,
             Flag also diagonal pixels (or only bottom/top/left/right)? 
             The default is True.
         - saturation/flag_rcsat : bool, optional
-            Flag RC pixels as saturated? The default is False.
+            Flag RC pixels as always saturated? The default is False.
         - refpix/nlower : int, optional
             Number of rows at frame bottom that shall be used as additional
-            reference pixels. The default is 0.
+            reference pixels. The default is 4.
         - refpix/nupper : int, optional
             Number of rows at frame top that shall be used as additional
-            reference pixels. The default is 0.
+            reference pixels. The default is 4.
+        - refpix/nrow_off : int, optional
+            Number of rows to offset the reference pixel region from the
+            bottom/top of the frame. The default is 0.
         - ramp_fit/save_calibrated_ramp : bool, optional
             Save the calibrated ramp? The default is False.
+
         Additional useful step parameters:
         - saturation/n_pix_grow_sat : int, optional
             Number of pixels to grow for saturation flagging. Default is 1.
@@ -924,7 +763,7 @@ def run_obs(database,
         Name of the directory where the data products shall be saved. The
         default is 'stage1'.
     overwrite : bool, optional
-        Overwrite existing files? Default is False.
+        Overwrite existing files? Default is True.
     quiet : bool, optional
         Use progress bar to track progress instead of messages. 
         Overrides verbose and sets it to False. Default is False.
@@ -947,14 +786,14 @@ def run_obs(database,
         Flag outlier pixels in rateints? Default is False.
         Uses the `cube_outlier_detection` function and requires
         a minimum of 5 integrations.
-    remove_ktc : bool, optional
+    flag_rcsat : bool, optional
+        Flag known RC pixels as always saturated? Default is False.
+    skip_ktc : bool, optional
         Remove kTC noise by fitting ramp data to get bias? 
-        Default is True.
-    remove_fnoise : bool, optional
-        Remove 1/f noise from data at group level? 
-        Default is True.
-    remove_fnoise_horiz : bool, optional
-        Remove striping noise from data in horizontal direction?
+        Useful for looking at linearized ramp data.
+        Default: False.
+    skip_fnoise : bool, optional
+        Skip 1/f noise removal? Default: False.
     skip_charge : bool, optional
         Skip charge migration flagging step? Default: False.
     skip_jump : bool, optional

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -522,7 +522,7 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
       edge rows and columns as reference pixels, run the JWST stage 1 refpix
       step, and unflag the pseudo reference pixels again. Only applicable for
       subarray data.
-    - Remove horizontal 1/f noise spatial striping in NIRCam data.
+    - Remove 1/f noise spatial striping in NIRCam data.
     
     Parameters
     ----------
@@ -589,8 +589,8 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
         Default: False.
     skip_fnoise : bool, optional
         Skip 1/f noise removal? Default: False.
-    skip_fnoise_horiz : bool, optional
-        Skip removal of horizontal striping? Default: False.
+    skip_fnoise_vert : bool, optional
+        Skip removal of vertical striping? Default: False.
         Not applied if 1/f noise correction is skipped.
     skip_charge : bool, optional
         Skip charge migration flagging step? Default: False.
@@ -603,7 +603,7 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     skip_ipc : bool, optional
         Skip IPC correction step? Default: False.
     skip_persistence : bool, optional
-        Skip persistence correction step? Default: False.
+        Skip persistence correction step? Default: True.
         Doesn't currently do anything.
 
     Returns
@@ -636,11 +636,11 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     pipeline.charge_migration.skip = kwargs.get('skip_charge', False)
     pipeline.jump.skip             = kwargs.get('skip_jump', False)
     pipeline.ipc.skip              = kwargs.get('skip_ipc', False)
-    pipeline.persistence.skip      = kwargs.get('skip_persistence', False)
+    pipeline.persistence.skip      = kwargs.get('skip_persistence', True)
     pipeline.subtract_ktc.skip     = kwargs.get('skip_ktc', False)
     pipeline.subtract_1overf.skip  = kwargs.get('skip_fnoise', False)
-    skip_horiz = kwargs.get('skip_fnoise_horiz', False)
-    pipeline.subtract_1overf.horizontal_corr = not skip_horiz
+    skip_vert = kwargs.get('skip_fnoise_vert', False)
+    pipeline.subtract_1overf.vertical_corr = not skip_vert
 
     # Skip dark current for subarray by default, but not full frame
     skip_dark     = kwargs.get('skip_dark', None)
@@ -675,11 +675,6 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     pipeline.saturation.grow_diagonal  = kwargs.get('grow_diagonal', False)
     pipeline.saturation.flag_rcsat     = kwargs.get('flag_rcsat', False)
     pipeline.rate_int_outliers         = kwargs.get('rate_int_outliers', False)
-
-    # 1/f noise correction
-    # pipeline.remove_ktc          = kwargs.get('remove_ktc', True)
-    # pipeline.remove_fnoise       = kwargs.get('remove_fnoise', True)
-    # pipeline.remove_fnoise_horiz = kwargs.get('remove_fnoise_horiz', True)
 
     # Skip pixels with only 1 group in ramp_fit?
     pipeline.ramp_fit.suppress_one_group = kwargs.get('suppress_one_group', False)
@@ -726,7 +721,7 @@ def run_obs(database,
       edge rows and columns as reference pixels, run the JWST stage 1 refpix
       step, and unflag the pseudo reference pixels again. Only applicable for
       subarray data.
-    - Remove horizontal 1/f noise spatial striping in NIRCam data.
+    - Remove 1/f noise spatial striping in NIRCam data.
     
     Parameters
     ----------
@@ -799,8 +794,8 @@ def run_obs(database,
         Default: False.
     skip_fnoise : bool, optional
         Skip 1/f noise removal? Default: False.
-    skip_fnoise_horiz : bool, optional
-        Skip removal of horizontal striping? Default: False.
+    skip_fnoise_vert : bool, optional
+        Skip removal of vertical striping? Default: False.
         Not applied if 1/f noise correction is skipped.
     skip_charge : bool, optional
         Skip charge migration flagging step? Default: False.
@@ -813,7 +808,7 @@ def run_obs(database,
     skip_ipc : bool, optional
         Skip IPC correction step? Default: False.
     skip_persistence : bool, optional
-        Skip persistence correction step? Default: False.
+        Skip persistence correction step? Default: True.
         Doesn't currently do anything.
 
     Returns

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -589,6 +589,9 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
         Default: False.
     skip_fnoise : bool, optional
         Skip 1/f noise removal? Default: False.
+    skip_fnoise_horiz : bool, optional
+        Skip removal of horizontal striping? Default: False.
+        Not applied if 1/f noise correction is skipped.
     skip_charge : bool, optional
         Skip charge migration flagging step? Default: False.
     skip_jump : bool, optional
@@ -636,6 +639,8 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     pipeline.persistence.skip      = kwargs.get('skip_persistence', False)
     pipeline.subtract_ktc.skip     = kwargs.get('skip_ktc', False)
     pipeline.subtract_1overf.skip  = kwargs.get('skip_fnoise', False)
+    skip_horiz = kwargs.get('skip_fnoise_horiz', False)
+    pipeline.subtract_1overf.horizontal_corr = not skip_horiz
 
     # Skip dark current for subarray by default, but not full frame
     skip_dark     = kwargs.get('skip_dark', None)
@@ -794,6 +799,9 @@ def run_obs(database,
         Default: False.
     skip_fnoise : bool, optional
         Skip 1/f noise removal? Default: False.
+    skip_fnoise_horiz : bool, optional
+        Skip removal of horizontal striping? Default: False.
+        Not applied if 1/f noise correction is skipped.
     skip_charge : bool, optional
         Skip charge migration flagging step? Default: False.
     skip_jump : bool, optional

--- a/spaceKLIP/fnoise_clean.py
+++ b/spaceKLIP/fnoise_clean.py
@@ -1,6 +1,5 @@
 import os
 import numpy as np
-from tqdm.auto import trange
 
 from jwst.stpipe import Step
 from jwst import datamodels
@@ -89,7 +88,7 @@ class OneOverfStep(Step):
             # Subtract 1/f noise from each integration
             datamodel = input_model.copy()
             data = datamodel.data
-            for i in trange(nints):
+            for i in range(nints):
                 cube = data[i] - bias_arr[i]
                 groupdq = datamodel.groupdq[i]
                 # Cumulative sum of group DQ flags

--- a/spaceKLIP/fnoise_clean.py
+++ b/spaceKLIP/fnoise_clean.py
@@ -156,11 +156,10 @@ class OneOverfStep(Step):
 
                     # Perform the fit and subtract model
                     nf_clean.fit(model_type=self.model_type, vertical_corr=self.vertical_corr)
-
-                    if i==0 and j==ngroups//2+1:
-                        self.quick_plot(data[i,j], nf_clean.M, nf_clean.model, im_diff=im_diff)
-
+                    # if i==0 and j==ngroups//2+1:
+                    #     self.quick_plot(data[i,j], nf_clean.M, nf_clean.model, im_diff=im_diff)
                     data[i,j] -= nf_clean.model
+
                     del nf_clean
 
         return datamodel
@@ -214,10 +213,10 @@ class OneOverfStep(Step):
 
                 # Perform the fit and subtract model
                 nf_clean.fit(model_type=self.model_type, vertical_corr=self.vertical_corr)
-                if i==0:
-                    self.quick_plot(datamodel.data[i], nf_clean.M, nf_clean.model, im_diff=im_diff)
-
+                # if i==0:
+                #     self.quick_plot(datamodel.data[i], nf_clean.M, nf_clean.model, im_diff=im_diff)
                 datamodel.data[i] -= nf_clean.model
+
                 del nf_clean
 
         return datamodel
@@ -245,9 +244,9 @@ class OneOverfStep(Step):
 
             # Perform the fit and subtract model
             nf_clean.fit(model_type=self.model_type, vertical_corr=self.vertical_corr)
-            self.quick_plot(datamodel.data, nf_clean.M, nf_clean.model)
-
+            # self.quick_plot(datamodel.data, nf_clean.M, nf_clean.model)
             datamodel.data -= nf_clean.model
+            
             del nf_clean
 
         return datamodel

--- a/spaceKLIP/fnoise_clean.py
+++ b/spaceKLIP/fnoise_clean.py
@@ -1,10 +1,14 @@
 import os
 import numpy as np
 
+import matplotlib
+import matplotlib.pyplot as plt
+
 from jwst.stpipe import Step
 from jwst import datamodels
 
 from webbpsf_ext import robust
+from webbpsf_ext.image_manip import expand_mask
 
 class kTCSubtractStep(Step):
     """
@@ -33,20 +37,39 @@ class kTCSubtractStep(Step):
 
 
 class OneOverfStep(Step):
-    """
-    OneOverfStep: Apply 1/f noise correction to group-level.
+    """ OneOverfStep: Apply 1/f noise correction
+
+    Works on `RampModel`, `CubeModel`, and `ImageModel` data products.
+
+    For `RampModel`, it creates a master slope image, then subtracts
+    a group-dependent flux image to produce a residual image. Then for
+    each group residual image, we model the 1/f noise using a Savitzky-Golay 
+    filter. 
+    
+    For `CubeModel`, we create an average of all slope images, then subtract
+    from each slope image to create a series of residual images. We then apply
+    a Savitzky-Golay filter to each residual image to model the 1/f noise.
+
+    Full frame channels are handled by first removing with common channel
+    noise (taking into account flips in the readout direction), then channel-dependent 
+    1/f noise is modeled and applied to a complete model of the full frame image.
+
+    If only a single integration is present, then a mask is applied to exclude
+    pixels with large flux values. These pixels are excluded during the model
+    fitting process.
     """
 
     class_alias = "1overf"
 
     spec = """
         model_type = option('median', 'mean', 'savgol', default='savgol') # Type of model to fit
-        horizontal_corr = boolean(default=True) # Apply horizontal correction
+        vertical_corr = boolean(default=False) # Apply horizontal correction
         sat_frac = float(default=0.5) # Maximum saturation fraction for fitting
+        combine_ints = boolean(default=False) # Combine integrations before fitting
     """
 
     def process(self, input):
-        """Apply 1/f noise correction to data.
+        """Apply 1/f noise correction to a JWST `RampModel`
 
         Parameters
         ==========
@@ -60,30 +83,55 @@ class OneOverfStep(Step):
             Output science data model with 1/f noise correction applied.
         """
 
+        if isinstance(input, datamodels.RampModel):
+            return self.proc_RampModel(input)
+        elif isinstance(input, datamodels.CubeModel):
+            return self.proc_CubeModel(input)
+        elif isinstance(input, datamodels.ImageModel):
+            return self.proc_ImageModel(input)
+        else:
+            raise ValueError(f"Do not recognize {type(input)}")
+
+    def proc_RampModel(self, input):
+        """Apply 1/f noise correction to a JWST `RampModel`
+
+        Parameters
+        ==========
+        input : JWST data model
+            Input science data model to be corrected.
+            Should be a linearized `RampModel`.
+        """
+
         # Get the input data model
         with datamodels.open(input) as input_model:
 
-            is_full_frame = 'FULL' in input_model.meta.subarray.name.upper()
             nints    = input_model.meta.exposure.nints
             ngroups  = input_model.meta.exposure.ngroups
             noutputs = input_model.meta.exposure.noutputs
 
-            ny, nx = input_model.data.shape[-2:]
-            chsize = ny // noutputs
-
-            # Fit slopes to get signal mask
-            # Grab slopes and bias values for each integration
-            bias_arr, slope_arr = fit_slopes_to_ramp_data(input_model, sat_frac=self.sat_frac)
-            # Remove bias from slopes and calculate mean slope
-            for i in range(nints):
-                slope_arr[i] -= bias_arr[i]
-            slope_mean = robust.mean(slope_arr, axis=0)
-
-            # Generate a mean signal ramp to subtract from each group
-            group_time = input_model.meta.exposure.group_time
-            ngroups = input_model.meta.exposure.ngroups
-            tarr = np.arange(1, ngroups+1) * group_time
-            signal_mean_ramp = slope_mean * tarr.reshape([-1,1,1])
+            # Fit slopes to get signal
+            # Grab biases for each integration and get average slope
+            bias_arr, slopes = fit_slopes_to_ramp_data(input_model, 
+                                                       sat_frac=self.sat_frac,
+                                                       combine_ints=self.combine_ints)
+            slope_mean = slopes if self.combine_ints else robust.mean(slopes, axis=0)
+            # print(nints, bias_arr.shape, slope_mean.shape)
+            
+            # If only a single integration, then apply a mask to exclude pixels
+            # with a large flux values. This will be used by the model fit.
+            if nints == 1:
+                # Signal ramp should be zeros, otherwise residuals would be ~0
+                signal_mean_ramp = np.zeros_like(input_model.data[0])
+                good_mask = robust.mean(slope_mean, return_mask=True)
+                # Expand mask by 1 pixel for good measure
+                good_mask = ~expand_mask(~good_mask, 1, grow_diagonal=True)
+            else:
+                # Generate a mean signal ramp to subtract from each group
+                group_time = input_model.meta.exposure.group_time
+                ngroups = input_model.meta.exposure.ngroups
+                tarr = np.arange(1, ngroups+1) * group_time
+                signal_mean_ramp = slope_mean * tarr.reshape([-1,1,1])
+                good_mask = np.ones_like(slope_mean, dtype=np.bool_)
 
             # Subtract 1/f noise from each integration
             datamodel = input_model.copy()
@@ -95,33 +143,142 @@ class OneOverfStep(Step):
                 bpmask_arr = np.cumsum(groupdq, axis=0) > 0
                 for j in range(ngroups):
 
-                    # Exclude bad pixels
-                    im_mask = ~bpmask_arr[j] # Good pixel mask
+                    # Good pixel mask
+                    im_mask = ~bpmask_arr[j] & good_mask
                     # Clean channel by channel
-                    for ch in range(noutputs):
-                        # Get channel x-indices
-                        x1 = int(ch*chsize)
-                        x2 = int(x1 + chsize)
+                    im_diff = cube[j] - signal_mean_ramp[j]
 
-                        # Channel subarrays
-                        imch = cube[j, :, x1:x2]
-                        sigch = signal_mean_ramp[j, :, x1:x2]
-                        good_mask = im_mask[:, x1:x2]
+                    # Select which clean function to use
+                    if noutputs>1:
+                        nf_clean = CleanFullFrame(im_diff, im_mask, nout=noutputs)
+                    else:
+                        nf_clean = CleanSubarray(im_diff, im_mask)
 
-                        # Remove averaged signal goup
-                        imch_diff = imch - sigch
+                    # Perform the fit and subtract model
+                    nf_clean.fit(model_type=self.model_type, vertical_corr=self.vertical_corr)
 
-                        # Subtract 1/f noise
-                        nf_clean = CleanSubarray(imch_diff, good_mask)
-                        nf_clean.fit(model_type=self.model_type, horizontal_corr=self.horizontal_corr)
-                        # Subtract model from data
-                        data[i,j,:,x1:x2] -= nf_clean.model
-                        del nf_clean
+                    if i==0 and j==ngroups//2+1:
+                        self.quick_plot(data[i,j], nf_clean.M, nf_clean.model, im_diff=im_diff)
+
+                    data[i,j] -= nf_clean.model
+                    del nf_clean
 
         return datamodel
     
+    def proc_CubeModel(self, input):
+        """ Apply 1/f noise correction to a JWST `CubeModel` 
 
-def fit_slopes_to_ramp_data(input, sat_frac=0.5):
+        Parameters
+        ==========
+        input : JWST data model
+            Input science data model to be corrected.
+            Should be a `CubeModel` such as rateints or calints.
+        """
+        # Get the input data model
+        with datamodels.open(input) as input_model:
+
+            nints    = input_model.meta.exposure.nints
+            noutputs = input_model.meta.exposure.noutputs
+            nints, ny, nx = input_model.data.shape
+            chsize = nx // noutputs
+
+            # If only a single integration, then apply a mask to exclude pixels
+            # with a large flux values. This will be used by the model fit.
+            if nints==1:
+                data_mean = np.zeros([ny, nx])
+                good_mask = robust.mean(input_model.data, return_mask=True)
+                # Expand mask by 1 pixel for good measure
+                good_mask = ~expand_mask(~good_mask, 1, grow_diagonal=True)
+            else:
+                # Get average of data
+                data = input_model.data.copy()
+                for i in range(nints):
+                    for ch in range(noutputs):
+                        x1 = int(ch*chsize)
+                        x2 = int(x1 + chsize)
+                        data[i,x1:x2] -= np.nanmedian(data[i,x1:x2])
+                data_mean = np.nanmean(data, axis=0)
+                good_mask = np.ones_like(data_mean, dtype=np.bool_)
+                del data
+
+            # Subtract 1/f noise from each integration
+            datamodel = input_model.copy()
+            for i in range(nints):
+                # Work on residual image
+                im_diff = datamodel.data[i] - data_mean
+                im_mask = (datamodel.dq[i] == 0) & good_mask
+
+                # Select which clean function to use
+                clean_func = CleanFullFrame if noutputs>1 else CleanSubarray
+                nf_clean = clean_func(im_diff, im_mask)
+
+                # Perform the fit and subtract model
+                nf_clean.fit(model_type=self.model_type, vertical_corr=self.vertical_corr)
+                if i==0:
+                    self.quick_plot(datamodel.data[i], nf_clean.M, nf_clean.model, im_diff=im_diff)
+
+                datamodel.data[i] -= nf_clean.model
+                del nf_clean
+
+        return datamodel
+
+    def proc_ImageModel(self, input):
+        """ Apply 1/f noise correction to a JWST `ImageModel` """
+        # Get the input data model
+        with datamodels.open(input) as input_model:
+
+            noutputs = input_model.meta.exposure.noutputs
+
+            # Only a single image, so apply a mask to exclude pixels
+            # with a large flux values. This will be used by the model fit.
+            good_mask = robust.mean(input_model.data, return_mask=True)
+            # Expand mask by 1 pixel for good measure
+            good_mask = ~expand_mask(~good_mask, 1, grow_diagonal=True)
+
+            # Subtract 1/f noise from each integration
+            datamodel = input_model.copy()
+
+            # Select which clean function to use
+            clean_func = CleanFullFrame if noutputs>1 else CleanSubarray
+            im_mask = (datamodel.dq == 0) & good_mask
+            nf_clean = clean_func(datamodel.data, im_mask)
+
+            # Perform the fit and subtract model
+            nf_clean.fit(model_type=self.model_type, vertical_corr=self.vertical_corr)
+            self.quick_plot(datamodel.data, nf_clean.M, nf_clean.model)
+
+            datamodel.data -= nf_clean.model
+            del nf_clean
+
+        return datamodel
+    
+    def quick_plot(self, image, mask, model, im_diff=None):
+
+        fig, axes = plt.subplots(2,2, figsize=(8,8), sharex=True, sharey=True)
+        axes = axes.flatten()
+
+        im_temp = im_diff if im_diff is not None else image
+        med = np.nanmedian(im_temp)
+        sig = robust.medabsdev(im_temp)
+        vmin, vmax = np.array([-1,1])*sig*3 + med
+        axes[0].imshow(im_temp, vmin=vmin, vmax=vmax)
+        axes[1].imshow(image - model, vmin=vmin, vmax=vmax)
+
+        # Plot mask
+        axes[2].imshow(mask)
+
+        med = np.nanmedian(model)
+        sig = robust.medabsdev(model)
+        vmin, vmax = np.array([-1,1])*sig*3 + med
+        axes[3].imshow(model, vmin=vmin, vmax=vmax, cmap='RdBu')
+
+        # print(np.nanmedian(im_diff), np.nanmedian(data[i,j]), np.nanmedian(nf_clean.model))
+        
+        fig.tight_layout()
+
+    
+
+def fit_slopes_to_ramp_data(input, sat_frac=0.5, combine_ints=False):
     """Fit slopes to each integration
     
     Uses custom `cube_fit` function to fit slopes to each integration.
@@ -137,6 +294,9 @@ def fit_slopes_to_ramp_data(input, sat_frac=0.5):
         this fraction of the saturation level are ignored.
         Default is 0.5 to ensure that the fit is within 
         the linear range.
+    combine_ints : bool
+        Average all integrations into a single array before fitting.
+        Return an (bias_arr, slope_mean). Default is False.
     """
     from jwst.datamodels import SaturationModel
     from jwst.saturation.saturation_step import SaturationStep
@@ -167,6 +327,7 @@ def fit_slopes_to_ramp_data(input, sat_frac=0.5):
     nints = input.meta.exposure.nints
     tarr = np.arange(1, ngroups+1) * group_time
     data = input.data
+    ny, nx = data.shape[-2:]
 
     bias_arr = []
     slope_arr = []
@@ -176,21 +337,194 @@ def fit_slopes_to_ramp_data(input, sat_frac=0.5):
         # Make sure to accumulate the group-level dq mask
         bpmask_arr = np.cumsum(groupdq, axis=0) > 0
         cf = cube_fit(tarr, data[i], bpmask_arr=bpmask_arr,
-                        sat_vals=sat_thresh, sat_frac=sat_frac)
+                      sat_vals=sat_thresh, sat_frac=sat_frac)
         bias_arr.append(cf[0])
         slope_arr.append(cf[1])
-    bias_arr = np.asarray(bias_arr)
-    slope_arr = np.asarray(slope_arr)
+    bias_arr = np.asarray(bias_arr).reshape([nints, ny, nx])
+    slope_arr = np.asarray(slope_arr).reshape([nints, ny, nx])
 
-    # bias and slope arrays have shape [nints, ny, nx]
-    # bias values are in units of DN and slope in DN/sec
-    return bias_arr, slope_arr
+    # Subtract biases, average, and refit?
+    if combine_ints and (nints > 1):
+        data = input.data.copy()
+        for i in range(nints):
+            data[i] -= bias_arr[i]
+            # Get group-level bpmask for this integration
+            groupdq = input.groupdq[i]
+            # Make sure to accumulate the group-level dq mask
+            bpmask_arr = np.cumsum(groupdq, axis=0) > 0
+            # Exclude bad pixels
+            data[i][bpmask_arr] = np.nan
+
+        data_mean = np.nanmean(data, axis=0)
+        bias_mean = np.nanmean(bias_arr, axis=0)
+        bpmask_arr = np.isnan(data_mean)
+        _, slope_mean = cube_fit(tarr, data_mean, bpmask_arr=bpmask_arr,
+                                 sat_vals=sat_thresh-bias_mean, sat_frac=sat_frac)
+        
+        # bias has shape [nints, ny, nx]
+        # slope has shape [ny, nx]
+        return bias_arr, slope_mean
+    elif combine_ints and (nints == 1):
+        # bias has shape [nints, ny, nx]
+        # slope has shape [ny, nx]
+        return bias_arr, slope_arr[0]
+    else:
+        # bias and slope arrays have shape [nints, ny, nx]
+        # bias values are in units of DN and slope in DN/sec
+        return bias_arr, slope_arr
 
 
+class CleanFullFrame:
+    """ Clean 1/f noise from full frame images
+
+    Use `CleanSubarray` instances to clean each channel separately.
+    First removes common channel noise, then cleans the residuals of 
+    each channel. Final full frame model is stored in `model` attribute. 
+    Intended for use on Level 1 or 2 pipeline products on any type of 
+    image product (group data, rateint, calint, rate, cal, etc). 
+    Suggest removing average signal levels from data and running
+    this on the residuals, which better reveal the 1/f noise structure.
+
+    Inspired by NSClean by Bernie Rauscher (https://arxiv.org/abs/2306.03250),
+    however instead of using FFTs and Matrix multiplication, this class uses
+    Savitzky-Golay filtering to model the 1/f noise and subtract it from the
+    data. This is significantly faster than the FFT approach and provides 
+    similar results. 
+    """
+
+    def __init__(self, data, mask, nout=4, exclude_outliers=True):
+
+        # Definitions
+        self.D = np.array(data, dtype=np.float32)
+        self.M = np.array(mask, dtype=np.bool_)
+        self.nout = nout
+        self.ny, self.nx = self.D.shape
+        self.chsize = self.nx // self.nout
+
+        # Average the channel data
+        self.average_channels()
+        # Create a subarray class for the average channel
+        chavg_mask = np.zeros_like(self.chavg, dtype=np.bool_)
+        for ch in range(nout):
+            x1 = int(ch*self.chsize)
+            x2 = int(x1 + self.chsize)
+            ch_mask = self.M[:,x1:x2]
+            if ch % 2 == 0:
+                ch_mask = np.flip(ch_mask, axis=1)
+            chavg_mask = chavg_mask | ch_mask
+        self.chavg_mask = chavg_mask
+        # self.output_classes = {}
+        self.output_classes = {
+            'chavg': CleanSubarray(self.chavg, self.chavg_mask, exclude_outliers=exclude_outliers)
+        }
+        
+        # Create subarray class for each channel
+        for ch in range(self.nout):
+            x1 = int(ch*self.chsize)
+            x2 = int(x1 + self.chsize)
+            self.output_classes[ch] = CleanSubarray(self.D[:,x1:x2], self.M[:,x1:x2], exclude_outliers=exclude_outliers)
+    
+    def average_channels(self):
+        """ Create an average channel image representing the common 1/f noise"""
+        data = self.D.copy()
+        data[~self.M] = np.nan
+
+        # Flip every other channel along x-axes
+        for ch in range(self.nout):
+            x1 = int(ch*self.chsize)
+            x2 = int(x1 + self.chsize)
+            data[:,x1:x2] -= np.nanmedian(data[:,x1:x2])
+            if ch % 2 == 0:
+                data[:,x1:x2] = np.flip(data[:,x1:x2], axis=1)
+
+        # Average channels
+        data = data.reshape([self.ny, self.nout, self.chsize])
+        self.chavg = np.nanmean(data, axis=1)
+
+    def fit(self, model_type='savgol', vertical_corr=False, **kwargs):
+
+        # Fit model to average channel
+        self.output_classes['chavg'].fit(model_type=model_type, vertical_corr=False, **kwargs)
+        chavg_model = self.output_classes['chavg'].model
+
+        # Get final models
+        final_model = np.zeros_like(self.D)
+        for ch in range(self.nout):
+            ch_class = self.output_classes[ch]
+
+            # Flip model every other channel
+            avgmod = np.flip(chavg_model, axis=1) if ch % 2 == 0 else chavg_model
+
+            # Subtract average channel model from data
+            ch_class.D -= avgmod
+            ch_class.fit(model_type=model_type, vertical_corr=vertical_corr, **kwargs)
+
+            # Add model back to data
+            x1 = int(ch*self.chsize)
+            x2 = int(x1 + self.chsize)
+            final_model[:,x1:x2] = ch_class.model + avgmod
+
+        self.model = final_model
+
+    def clean(self, model_type='savgol', vertical_corr=False, **kwargs):
+        """ Clean the data
+
+        Overwrites data in-place with the cleaned data.
+        
+        Parameters
+        ==========
+        model_type : str
+            Must be 'median', 'mean', or 'savgol'. For 'mean' case,
+            it uses a robust mean that ignores outliers and NaNs.
+            The 'median' case uses `np.nanmedian`. The 'savgol' case
+            uses a Savitzky-Golay filter to model the 1/f noise, 
+            iteratively rejecting outliers from the model fit relative
+            to the median model. The default is 'savgol'.
+        vertical_corr : bool
+            Apply a horizontal correction to the data. This is useful
+            for removing horizontal striping. The default is False.
+
+        Keyword Args
+        ============
+        niter : int
+            Number of iterations to use for rejecting outliers during
+            the model fit. If the number of rejected pixels does not
+            change between iterations, then the fit is considered
+            converged and the loop is broken.
+        winsize : int
+            Size of the window filter. Should be an odd number.
+        order : int
+            Order of the polynomial used to fit the samples.
+        per_line : bool
+            Smooth each channel line separately with the hopes of avoiding
+            edge discontinuities.
+        mask : bool image or None
+            An image mask of pixels to ignore. Should be same size as im_arr.
+            This can be used to mask pixels that the filter should ignore, 
+            such as stellar sources or pixel outliers. A value of True indicates
+            that pixel should be ignored.
+        mode : str
+            Must be 'mirror', 'constant', 'nearest', 'wrap' or 'interp'.  This
+            determines the type of extension to use for the padded signal to
+            which the filter is applied.  When `mode` is 'constant', the padding
+            value is given by `cval`. 
+            When the 'interp' mode is selected (the default), no extension
+            is used.  Instead, a degree `polyorder` polynomial is fit to the
+            last `window_length` values of the edges, and this polynomial is
+            used to evaluate the last `window_length // 2` output values.
+        cval : float
+            Value to fill past the edges of the input if `mode` is 'constant'.
+            Default is 0.0.
+        """ 
+        # Fit the background model
+        self.fit(model_type=model_type, vertical_corr=vertical_corr, **kwargs) 
+        self.D -= self.model # Overwrite data with cleaned data
+        return self.D
 
 
 class CleanSubarray:
-    """
+    """ 1/f noise modeling and subtraction for HAWAII-2RG subarrays.
+
     CleanSubarray is the base class for removing residual correlated
     read noise from generic JWST near-IR Subarray images.  It is
     intended for use on Level 1 or 2 pipeline products on any type of
@@ -203,28 +537,27 @@ class CleanSubarray:
     Savitzky-Golay filtering to model the 1/f noise and subtract it from the
     data. This is significantly faster than the FFT approach and provides 
     similar results. 
+
+    This function assumes such that the slow-scan runs vertically along the
+    y-axis, while the fast scan direction runs horizontally. Direction 
+    (left to right or right to left) is irrelevant.
     """
             
     def __init__(self, data, mask, exclude_outliers=True):
-        """ 1/f noise modeling and subtraction for HAWAII-2RG subarrays.
-
-        This function assumes such that the slow-scan runs vertically along the
-        y-axis, while the fast scan direction runs horizontally. Direction 
-        (left to right or right to left) is irrelevant. 
+        """ Initialize the class
 
         Parameters
         ==========
-        D : ndarray
+        data : ndarray
             Two-dimensional input data.
-        M : ndarray
+        mask : ndarray
             Two dimensional background pixels mask. 
-            Pixels =True are modeled as background.
-            Pixels=False are excluded from the background model.
+            Pixels = True are modeled as background.
+            Pixels = False are excluded from the background model.
         exclude_outliers : bool
             Exclude statistical outliers and their nearest neighbors
             from the background pixels mask.
         """
-        from .utils import expand_mask
 
         # Definitions
         self.D = np.array(data, dtype=np.float32)
@@ -247,14 +580,14 @@ class CleanSubarray:
 
     @property
     def nx(self):
-        """ Number of pixels in fast scan direction"""
-        return np.int32(self.D.shape[1])
+        """ Number of columns in the image """
+        return self.D.shape[1]
     @property
     def ny(self):
-        """ Number of pixels in slow scan direction"""
-        return np.int32(self.D.shape[0])
+        """ Number of rows in the image """
+        return self.D.shape[0]
 
-    def fit(self, model_type='savgol', horizontal_corr=False, **kwargs):
+    def fit(self, model_type='savgol', vertical_corr=False, **kwargs):
         """ Return the model which is just median of each row
         
         Parameters
@@ -266,9 +599,9 @@ class CleanSubarray:
             uses a Savitzky-Golay filter to model the 1/f noise, 
             iteratively rejecting outliers from the model fit relative
             to the median model. The default is 'savgol'.
-        horizontal_corr : bool
-            Apply a horizontal correction to the data. This is useful
-            for removing horizontal striping. The default is False.
+        vertical_corr : bool
+            Apply a vertical correction to the data. This is useful
+            for removing vertical striping. The default is False.
         """
 
         # Fit the model
@@ -282,21 +615,23 @@ class CleanSubarray:
             raise ValueError(f"Do not recognize model_type={model_type}")
         
         # Apply horizontal correction
-        if horizontal_corr:
+        if vertical_corr:
             data = self.D.copy()
-            model = self.model.copy()
+            mask = self.M.copy()
+            model_vert = self.model.copy()
             # Rotate model subtracted data by 90 degrees
-            self.D = np.rot90(data - model, k=1)
-            self.M = np.rot90(self.M, k=1)
+            self.D = np.rot90(data - model_vert, k=1, axes=(0,1))
+            self.M = np.rot90(self.M, k=1, axes=(0,1))
             # Fit the model
-            self.fit(model_type=model_type, horizontal_corr=False, **kwargs)
+            self.fit(model_type=model_type, vertical_corr=False, **kwargs)
             
-            # Rotate data and model back to original orientation
-            self.D = np.rot90(self.D, k=-1)
-            self.M = np.rot90(self.M, k=-1)
-            self.model = np.rot90(self.model, k=-1) + model
+            # Return data and mask to original orientation
+            self.D = data
+            # self.M = mask
+            self.M = np.rot90(self.M, k=-1, axes=(0,1))
+            self.model = np.rot90(self.model, k=-1, axes=(0,1)) + model_vert
 
-            del model, data
+            del model_vert
 
     def _fit_median(self, robust_mean=False):
         """ Return the model which is just median of each row
@@ -375,7 +710,7 @@ class CleanSubarray:
 
         return model
         
-    def clean(self, model_type='savgol', horizontal_corr=False, **kwargs):
+    def clean(self, model_type='savgol', vertical_corr=False, **kwargs):
         """ Clean the data
 
         Overwrites data in-place with the cleaned data.
@@ -389,7 +724,7 @@ class CleanSubarray:
             uses a Savitzky-Golay filter to model the 1/f noise, 
             iteratively rejecting outliers from the model fit relative
             to the median model. The default is 'savgol'.
-        horizontal_corr : bool
+        vertical_corr : bool
             Apply a horizontal correction to the data. This is useful
             for removing horizontal striping. The default is False.
 
@@ -426,7 +761,7 @@ class CleanSubarray:
             Default is 0.0.
         """ 
         # Fit the background model
-        self.fit(model_type=model_type, horizontal_corr=horizontal_corr, **kwargs) 
+        self.fit(model_type=model_type, vertical_corr=vertical_corr, **kwargs) 
         self.D -= self.model # Overwrite data with cleaned data
         return self.D
 

--- a/spaceKLIP/fnoise_clean.py
+++ b/spaceKLIP/fnoise_clean.py
@@ -63,9 +63,9 @@ class OneOverfStep(Step):
 
     spec = """
         model_type = option('median', 'mean', 'savgol', default='savgol') # Type of model to fit
-        vertical_corr = boolean(default=False) # Apply horizontal correction
         sat_frac = float(default=0.5) # Maximum saturation fraction for fitting
-        combine_ints = boolean(default=False) # Combine integrations before fitting
+        combine_ints = boolean(default=True) # Combine integrations before ramp fitting
+        vertical_corr = boolean(default=True) # Apply horizontal correction
     """
 
     def process(self, input):

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -916,7 +916,7 @@ def chisqr_red(yvals, yfit=None, err=None, dof=None,
         
     return chi_red
 
-def cube_outlier_detection(data, sigma_cut=10, nint_min=5):
+def cube_outlier_detection(data, sigma_cut=10, nint_min=10):
     """Get outlier pixels in a cube model (e.g., rateints or calints)
     
     Parameters


### PR DESCRIPTION
Removed the SavGol 1/f correction code from the pipeline and packaged it all into a jwst `Step` class and placed in the `fnoise_clean.py` file. Now this works similarly to other steps within jwst pipelines. Similarly created and added a kTC subtraction Step class `kTCSubtractStep`. Overall, the PR shouldn't change anything to the outputs or results, but simply cleans up the pipeline code and allows reuse of the 1/f correction for other pipelines.

Vertical striping correction is now applied in the `CleanSubarry` class and can be turned off and on in the `OneOverfStep` class via the `vertical_corr` parameter. (e.g., `pipeline.subtract_1overf.vertical_corr`). This has been turned on by default.

Full frame subarrays are now cleaned more intelligently via the implementation of the `CleanFullFrame` class. This first determines common-mode 1/f noise between the four channels, subtract that from each channel (accounting for channel flips along the x-axis), then models the residuals to determine channel-dependent 1/f noise. These are then all combined to create a full frame

Added logic to better handle cases where only a single integration is present. In that case, we are unable to work on residuals, so we simply apply an outlier mask to exclude pixels with high flux. The fitting routine then dynamically adapts the mask based on noise-subtracted residuals.