### PR TITLE
Removing COM substrate correction & bugfix with phase_cross_correlation

### DIFF
--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -234,9 +234,9 @@ class AnalysisTools():
                     cons_mask = np.array(cons_mask)
                 
                 # Apply COM substrate transmission.
-                cons /= tp_comsubst
-                if mask is not None:
-                    cons_mask /= tp_comsubst
+                # cons /= tp_comsubst
+                # if mask is not None:
+                #     cons_mask /= tp_comsubst
                 
                 # Plot masked data.
                 klmodes = self.database.red[key]['KLMODES'][j].split(',')
@@ -663,7 +663,7 @@ class AnalysisTools():
                         
                         # Apply scale factor to incorporate the COM substrate
                         # transmission.
-                        offsetpsf *= tp_comsubst
+                        # offsetpsf *= tp_comsubst
                         
                         # Blur frames with a Gaussian filter.
                         if not np.isnan(self.database.obs[key]['BLURFWHM'][ww]):
@@ -798,6 +798,7 @@ class AnalysisTools():
                         
                         # MCMC.
                         if fitmethod == 'mcmc':
+                            # fm_frame *= -1
                             fma = fitpsf.FMAstrometry(guess_sep=guess_sep,
                                                       guess_pa=guess_pa,
                                                       fitboxsize=fitboxsize)

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -1902,11 +1902,12 @@ class ImageTools():
                                     npix=fov_pix)
             
             # Determine relative shift between data and model PSF.
-            yshift, xshift = phase_cross_correlation(datasub * masksub,
-                                                     model_psf * masksub,
-                                                     upsample_factor=1000,
-                                                     normalization=None,
-                                                     return_error=False)
+            shift, error, phasediff = phase_cross_correlation(datasub * masksub,
+                                                              model_psf * masksub,
+                                                              upsample_factor=1000,
+                                                              normalization=None,
+                                                              return_error=False)
+            yshift, xshift = shift
             
             # Update star position.
             xc = np.mean(xsub_indarr) + xshift

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -245,7 +245,7 @@ class SpaceTelescope(Data):
             iwa_all = 1.  # pix
 
         # Recenter science images.
-        new_center = (np.array(data.shape[1:])-1)/ 2.
+        new_center = np.array(data.shape[1:])/ 2.
         new_center = new_center[::-1]
         for i, image in enumerate(input_all):
             recentered_image = pyklip.klip.align_and_scale(image, new_center=new_center, old_center=centers_all[i])
@@ -326,7 +326,7 @@ class SpaceTelescope(Data):
         psflib_filenames_all = np.array(psflib_filenames_all)
         
         # Recenter reference images.
-        new_center = (np.array(data.shape[1:])-1)/ 2.
+        new_center = np.array(data.shape[1:])/ 2.
         new_center = new_center[::-1]
         for i, image in enumerate(psflib_data_all):
             recentered_image = pyklip.klip.align_and_scale(image, new_center=new_center, old_center=psflib_centers_all[i])


### PR DESCRIPTION
After discussions with the NIRCam Team we are removing the COM substrate correction as it had already been accounted for in the JWST pipeline photometric calibration (@mperrin @AarynnCarter).