### PR TITLE
coron2pipeline save_intermediates

### DIFF
--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -39,6 +39,10 @@ class Coron2Pipeline_spaceKLIP(Image2Pipeline):
     """
     
     class_alias = "calwebb_coron2"
+    
+    spec = """
+        save_intermediates = boolean(default=False) # Save all intermediate step results
+    """
 
     def __init__(self,
                  **kwargs):


### PR DESCRIPTION
The `coron2pipeline` has options to save intermediate data products. However, the `save_intermediates` attribute is not actually defined during init (it has has instead been defined during SpaceKLIP's higher level calls, though). This fix adds it to the class init with a default value of `False`. 