### PR TITLE
enhance MAST query interface and add download capabilities

### DIFF
--- a/docs/source/tutorials/MAST query tools for coronagraphic datasets.ipynb
+++ b/docs/source/tutorials/MAST query tools for coronagraphic datasets.ipynb
@@ -5,12 +5,20 @@
    "id": "e0e954ad",
    "metadata": {},
    "source": [
-    "# MAST query tools for coronagraphic datasets\n",
+    "# MAST query and download tools for coronagraphic datasets\n",
     "\n",
     "SpaceKLIP includes some simple query tools for searching available coronagraphic datasets in MAST. \n",
     "\n",
     "These are intended for, for instance, determining if there are PSF or background observations from other programs\n",
     "that may be useful in reducing a given science dataset. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e94918b2",
+   "metadata": {},
+   "source": [
+    "## Finding available PSF reference or background observations"
    ]
   },
   {
@@ -32,87 +40,36 @@
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 34 total rows. Here's the first few:\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
-       "<div><i>Table length=34</i>\n",
-       "<table id=\"table140685167378144\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>visit_id</th><th>start time</th><th>filter</th><th>kind</th><th>coronmsk</th><th>targname</th><th>obslabel</th><th>duration</th><th>numdthpt</th><th>program</th><th>title</th><th>pi_name</th></tr></thead>\n",
-       "<thead><tr><th>str12</th><th>str16</th><th>str5</th><th>bytes3</th><th>str9</th><th>str22</th><th>str54</th><th>float64</th><th>int64</th><th>int64</th><th>str75</th><th>str20</th></tr></thead>\n",
-       "<tr><td>V01386001001</td><td>2022-07-29 22:01</td><td>F356W</td><td>REF</td><td>MASKA335R</td><td>* phi Cen</td><td>NIRCam 335R - REF</td><td>83.426</td><td>9</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
-       "<tr><td>V01386002001</td><td>2022-07-30 01:13</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>HD 116434</td><td>NIRCam 335R - Roll 1</td><td>617.946</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
-       "<tr><td>V01386003001</td><td>2022-07-30 03:16</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>HD 116434</td><td>NIRCam 335R - Roll 2</td><td>617.946</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
-       "<tr><td>V01184015001</td><td>2022-09-06 00:00</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>LP 944-20</td><td>LP 944-20 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184016001</td><td>2022-09-06 01:43</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>LP 944-20</td><td>LP 944-20 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184017001</td><td>2022-09-06 03:19</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>2MASSI J0443376+000205</td><td>2MJ0443 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184018001</td><td>2022-09-06 05:02</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>2MASSI J0443376+000205</td><td>2MJ0443 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184001001</td><td>2022-10-03 04:37</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>V* AU Mic</td><td>AU Mic roll 1</td><td>872.685</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184002001</td><td>2022-10-03 08:34</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>V* AU Mic</td><td>AU Mic roll 2</td><td>872.685</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184003001</td><td>2022-10-03 10:03</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G 80-21</td><td>HIP17695 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184004001</td><td>2022-10-03 12:08</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G 80-21</td><td>HIP17695 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184005001</td><td>2022-10-03 13:36</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G-7-34</td><td>G 7-34 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184006001</td><td>2022-10-03 15:37</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G-7-34</td><td>G 7-34 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184008001</td><td>2022-10-03 19:02</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>LP 776-25</td><td>TYC5899 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01412001001</td><td>2022-10-19 19:41</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* c Eri</td><td>51 Eri - NIRCam - Roll 1 - MASK430R</td><td>630.299</td><td>1</td><td>1412</td><td>Characterizing 51 Eridani Exoplanetary System</td><td>Perrin, Marshall</td></tr>\n",
-       "<tr><td>V01412003001</td><td>2022-10-19 23:20</td><td>F356W</td><td>REF</td><td>MASKA430R</td><td>HD 30562</td><td>Ref star - NIRCam - MASK430R</td><td>231.158</td><td>5</td><td>1412</td><td>Characterizing 51 Eridani Exoplanetary System</td><td>Perrin, Marshall</td></tr>\n",
-       "<tr><td>V01412006001</td><td>2022-10-20 06:12</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* c Eri</td><td>51 Eri - NIRCam - Roll 2 - MASK430R</td><td>630.299</td><td>1</td><td>1412</td><td>Characterizing 51 Eridani Exoplanetary System</td><td>Perrin, Marshall</td></tr>\n",
-       "<tr><td>V01193014001</td><td>2022-10-22 06:13</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* alf PsA</td><td>Fomalhaut - NIRCam - Roll 1 - FULL - MA430R</td><td>407.997</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01193015001</td><td>2022-10-22 07:12</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* alf PsA</td><td>Fomalhaut - NIRCam - Roll 1 - SUB320 - MA430R</td><td>451.147</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01193016001</td><td>2022-10-22 07:58</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* alf PsA</td><td>Fomalhaut - NIRCam - Roll 2 - SUB320 - M430R</td><td>451.147</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01193017001</td><td>2022-10-22 09:09</td><td>F356W</td><td>SCI</td><td>MASKA430R</td><td>* alf PsA</td><td>Fomalhaut - NIRCam - Roll 2 - FULL - M430R</td><td>407.997</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01193018001</td><td>2022-10-22 09:46</td><td>F356W</td><td>REF</td><td>MASKA430R</td><td>* del Aqr</td><td>Fomalhaut Ref star - NIRCam - Roll 2 - SUB320 - MA430R</td><td>182.085</td><td>5</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01193019001</td><td>2022-10-22 11:16</td><td>F356W</td><td>REF</td><td>MASKA430R</td><td>* del Aqr</td><td>Fomalhaut Ref star - NIRCam - Roll 2 - FULL - MA430R</td><td>150.315</td><td>5</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01184009001</td><td>2022-11-26 15:52</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>FOMALHAUT-C</td><td>Fomalhaut C roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184010001</td><td>2022-11-26 21:09</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>FOMALHAUT-C</td><td>Fomalhaut C roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184011001</td><td>2022-11-26 22:34</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>V* AP Col</td><td>AP Col roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184012001</td><td>2022-11-27 00:54</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>V* AP Col</td><td>AP Col roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184013001</td><td>2022-11-27 02:19</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G 161-71</td><td>2MJ0944 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184014001</td><td>2022-11-27 04:18</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>G 161-71</td><td>2MJ0944 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01194001001</td><td>2022-11-27 17:40</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>HR8799</td><td>HR 8799 - NIRCam - Roll 1 - MASK335R</td><td>454.854</td><td>1</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01194003001</td><td>2022-11-27 19:08</td><td>F356W</td><td>REF</td><td>MASKA335R</td><td>* ups Peg\\`</td><td>Ref star - NIRCam - MASK335R</td><td>72.777</td><td>5</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01194006001</td><td>2022-11-27 21:03</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>HR8799</td><td>HR 8799 - NIRCam - Roll 2 - MASK335R</td><td>454.854</td><td>1</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01184027001</td><td>2023-02-11 14:45</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>LP 776-25</td><td>TYC5899 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
-       "<tr><td>V01184028001</td><td>2023-02-22 18:16</td><td>F356W</td><td>SCI</td><td>MASKA335R</td><td>LP 776-25</td><td>TYC5899 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<div><i>Table length=5</i>\n",
+       "<table id=\"table11262186000\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>visit_id</th><th>start time</th><th>filter</th><th>coronmsk</th><th>targname</th><th>obslabel</th><th>duration</th><th>numdthpt</th><th>program</th><th>title</th><th>pi_name</th></tr></thead>\n",
+       "<thead><tr><th>str12</th><th>str16</th><th>str5</th><th>str9</th><th>str22</th><th>str54</th><th>float64</th><th>int64</th><th>int64</th><th>str75</th><th>str20</th></tr></thead>\n",
+       "<tr><td>V01386001001</td><td>2022-07-29 22:01</td><td>F356W</td><td>MASKA335R</td><td>* phi Cen</td><td>NIRCam 335R - REF</td><td>83.426</td><td>9</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386002001</td><td>2022-07-30 01:13</td><td>F356W</td><td>MASKA335R</td><td>HD 116434</td><td>NIRCam 335R - Roll 1</td><td>617.946</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386003001</td><td>2022-07-30 03:16</td><td>F356W</td><td>MASKA335R</td><td>HD 116434</td><td>NIRCam 335R - Roll 2</td><td>617.946</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01184015001</td><td>2022-09-06 00:00</td><td>F356W</td><td>MASKA335R</td><td>LP 944-20</td><td>LP 944-20 roll 1</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
+       "<tr><td>V01184016001</td><td>2022-09-06 01:43</td><td>F356W</td><td>MASKA335R</td><td>LP 944-20</td><td>LP 944-20 roll 2</td><td>846.844</td><td>1</td><td>1184</td><td>A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs</td><td>Schlieder, Joshua</td></tr>\n",
        "</table></div>"
       ],
       "text/plain": [
-       "<Table length=34>\n",
-       "  visit_id      start time    filter  kind   coronmsk        targname        ... duration numdthpt program                                    title                                          pi_name       \n",
-       "   str12          str16        str5  bytes3    str9           str22          ... float64   int64    int64                                     str75                                           str20        \n",
-       "------------ ---------------- ------ ------ --------- ---------------------- ... -------- -------- ------- --------------------------------------------------------------------------- --------------------\n",
-       "V01386001001 2022-07-29 22:01  F356W    REF MASKA335R              * phi Cen ...   83.426        9    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
-       "V01386002001 2022-07-30 01:13  F356W    SCI MASKA335R              HD 116434 ...  617.946        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
-       "V01386003001 2022-07-30 03:16  F356W    SCI MASKA335R              HD 116434 ...  617.946        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
-       "V01184015001 2022-09-06 00:00  F356W    SCI MASKA335R              LP 944-20 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184016001 2022-09-06 01:43  F356W    SCI MASKA335R              LP 944-20 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184017001 2022-09-06 03:19  F356W    SCI MASKA335R 2MASSI J0443376+000205 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184018001 2022-09-06 05:02  F356W    SCI MASKA335R 2MASSI J0443376+000205 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184001001 2022-10-03 04:37  F356W    SCI MASKA335R              V* AU Mic ...  872.685        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184002001 2022-10-03 08:34  F356W    SCI MASKA335R              V* AU Mic ...  872.685        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184003001 2022-10-03 10:03  F356W    SCI MASKA335R                G 80-21 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184004001 2022-10-03 12:08  F356W    SCI MASKA335R                G 80-21 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184005001 2022-10-03 13:36  F356W    SCI MASKA335R                 G-7-34 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184006001 2022-10-03 15:37  F356W    SCI MASKA335R                 G-7-34 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184008001 2022-10-03 19:02  F356W    SCI MASKA335R              LP 776-25 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01412001001 2022-10-19 19:41  F356W    SCI MASKA430R                * c Eri ...  630.299        1    1412                               Characterizing 51 Eridani Exoplanetary System     Perrin, Marshall\n",
-       "V01412003001 2022-10-19 23:20  F356W    REF MASKA430R               HD 30562 ...  231.158        5    1412                               Characterizing 51 Eridani Exoplanetary System     Perrin, Marshall\n",
-       "V01412006001 2022-10-20 06:12  F356W    SCI MASKA430R                * c Eri ...  630.299        1    1412                               Characterizing 51 Eridani Exoplanetary System     Perrin, Marshall\n",
-       "V01193014001 2022-10-22 06:13  F356W    SCI MASKA430R              * alf PsA ...  407.997        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
-       "V01193015001 2022-10-22 07:12  F356W    SCI MASKA430R              * alf PsA ...  451.147        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
-       "V01193016001 2022-10-22 07:58  F356W    SCI MASKA430R              * alf PsA ...  451.147        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
-       "V01193017001 2022-10-22 09:09  F356W    SCI MASKA430R              * alf PsA ...  407.997        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
-       "V01193018001 2022-10-22 09:46  F356W    REF MASKA430R              * del Aqr ...  182.085        5    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
-       "V01193019001 2022-10-22 11:16  F356W    REF MASKA430R              * del Aqr ...  150.315        5    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
-       "V01184009001 2022-11-26 15:52  F356W    SCI MASKA335R            FOMALHAUT-C ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184010001 2022-11-26 21:09  F356W    SCI MASKA335R            FOMALHAUT-C ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184011001 2022-11-26 22:34  F356W    SCI MASKA335R              V* AP Col ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184012001 2022-11-27 00:54  F356W    SCI MASKA335R              V* AP Col ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184013001 2022-11-27 02:19  F356W    SCI MASKA335R               G 161-71 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184014001 2022-11-27 04:18  F356W    SCI MASKA335R               G 161-71 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01194001001 2022-11-27 17:40  F356W    SCI MASKA335R                 HR8799 ...  454.854        1    1194          Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
-       "V01194003001 2022-11-27 19:08  F356W    REF MASKA335R            * ups Peg\\` ...   72.777        5    1194          Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
-       "V01194006001 2022-11-27 21:03  F356W    SCI MASKA335R                 HR8799 ...  454.854        1    1194          Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
-       "V01184027001 2023-02-11 14:45  F356W    SCI MASKA335R              LP 776-25 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua\n",
-       "V01184028001 2023-02-22 18:16  F356W    SCI MASKA335R              LP 776-25 ...  846.844        1    1184              A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs    Schlieder, Joshua"
+       "<Table length=5>\n",
+       "  visit_id      start time    filter  coronmsk  targname       obslabel       duration numdthpt program                                 title                                       pi_name     \n",
+       "   str12          str16        str5     str9     str22          str54         float64   int64    int64                                  str75                                        str20      \n",
+       "------------ ---------------- ------ --------- --------- -------------------- -------- -------- ------- ---------------------------------------------------------------------- -----------------\n",
+       "V01386001001 2022-07-29 22:01  F356W MASKA335R * phi Cen    NIRCam 335R - REF   83.426        9    1386 High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST    Hinkley, Sasha\n",
+       "V01386002001 2022-07-30 01:13  F356W MASKA335R HD 116434 NIRCam 335R - Roll 1  617.946        1    1386 High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST    Hinkley, Sasha\n",
+       "V01386003001 2022-07-30 03:16  F356W MASKA335R HD 116434 NIRCam 335R - Roll 2  617.946        1    1386 High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST    Hinkley, Sasha\n",
+       "V01184015001 2022-09-06 00:00  F356W MASKA335R LP 944-20     LP 944-20 roll 1  846.844        1    1184         A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs Schlieder, Joshua\n",
+       "V01184016001 2022-09-06 01:43  F356W MASKA335R LP 944-20     LP 944-20 roll 2  846.844        1    1184         A NIRCam Coronagraphic Imaging Survey of Nearby Young M Dwarfs Schlieder, Joshua"
       ]
      },
      "execution_count": 1,
@@ -123,7 +80,10 @@
    "source": [
     "import spaceKLIP\n",
     "\n",
-    "spaceKLIP.mast.query_coron_datasets('NIRCam', 'F356W')"
+    "table = spaceKLIP.mast.query_coron_datasets('NIRCam', 'F356W')\n",
+    "\n",
+    "print(f\"Found {len(table)} total rows. Here's the first few:\")\n",
+    "table[:5]"
    ]
   },
   {
@@ -146,37 +106,47 @@
     {
      "data": {
       "text/html": [
-       "<div><i>Table length=10</i>\n",
-       "<table id=\"table140685155184208\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>visit_id</th><th>start time</th><th>filter</th><th>kind</th><th>coronmsk</th><th>targname</th><th>obslabel</th><th>duration</th><th>numdthpt</th><th>program</th><th>title</th><th>pi_name</th></tr></thead>\n",
-       "<thead><tr><th>str12</th><th>str16</th><th>str6</th><th>bytes3</th><th>str9</th><th>str9</th><th>str25</th><th>float64</th><th>int64</th><th>int64</th><th>str80</th><th>str20</th></tr></thead>\n",
-       "<tr><td>V01045069001</td><td>2022-06-13 17:35</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 92209</td><td>4QPM - F1550C</td><td>774.406</td><td>9</td><td>1045</td><td>MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition</td><td>Dicken, Daniel</td></tr>\n",
-       "<tr><td>V01037010001</td><td>2022-06-18 15:04</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 163113</td><td>4QPM - F1550C</td><td>2299.49</td><td>9</td><td>1037</td><td>MIRI Coronagraphic Contrast Ratios</td><td>Boccaletti, Anthony</td></tr>\n",
-       "<tr><td>V01037011001</td><td>2022-06-18 21:13</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 162989</td><td>Ref 1 deg F1550C</td><td>2299.49</td><td>9</td><td>1037</td><td>MIRI Coronagraphic Contrast Ratios</td><td>Boccaletti, Anthony</td></tr>\n",
-       "<tr><td>V01386007001</td><td>2022-07-17 20:48</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>* phi Cen</td><td>MIRI 1550C - REF</td><td>459.706</td><td>9</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
-       "<tr><td>V01045088001</td><td>2022-07-19 10:02</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 92209</td><td>4QPM - F1550C</td><td>2299.49</td><td>5</td><td>1045</td><td>MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition</td><td>Dicken, Daniel</td></tr>\n",
-       "<tr><td>V01386027001</td><td>2022-08-02 17:02</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 140986</td><td>MIRI F1550C - REF</td><td>1726.894</td><td>5</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
-       "<tr><td>V01193004001</td><td>2022-10-21 18:48</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>* 19 PsA</td><td>FomalhautPSF-1550C</td><td>202.29</td><td>9</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01194016001</td><td>2022-11-08 15:17</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 218261</td><td>REF 1550C</td><td>239.92</td><td>9</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01411008001</td><td>2022-12-13 08:54</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>* alf Pic</td><td>Alpha Pic - 1550 4QPM PSF</td><td>725.991</td><td>5</td><td>1411</td><td>Coronagraphy of the Debris Disk Archetype Beta Pictoris</td><td>Stark, Chris</td></tr>\n",
-       "<tr><td>V01241041001</td><td>2023-03-10 19:02</td><td>F1550C</td><td>REF</td><td>4QPM_1550</td><td>HD 49518</td><td>Ref HR 2562 - F1550C</td><td>357.123</td><td>5</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
+       "<div><i>Table length=15</i>\n",
+       "<table id=\"table11262530128\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>visit_id</th><th>start time</th><th>filter</th><th>coronmsk</th><th>targname</th><th>obslabel</th><th>duration</th><th>numdthpt</th><th>program</th><th>title</th><th>pi_name</th></tr></thead>\n",
+       "<thead><tr><th>str12</th><th>str16</th><th>str6</th><th>str9</th><th>str23</th><th>str42</th><th>float64</th><th>int64</th><th>int64</th><th>str80</th><th>str21</th></tr></thead>\n",
+       "<tr><td>V01045069001</td><td>2022-06-13 17:35</td><td>F1550C</td><td>4QPM_1550</td><td>HD 92209</td><td>4QPM - F1550C</td><td>774.406</td><td>9</td><td>1045</td><td>MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition</td><td>Dicken, Daniel</td></tr>\n",
+       "<tr><td>V01037010001</td><td>2022-06-18 15:04</td><td>F1550C</td><td>4QPM_1550</td><td>HD 163113</td><td>4QPM - F1550C</td><td>2299.49</td><td>9</td><td>1037</td><td>MIRI Coronagraphic Contrast Ratios</td><td>Boccaletti, Anthony</td></tr>\n",
+       "<tr><td>V01037011001</td><td>2022-06-18 21:13</td><td>F1550C</td><td>4QPM_1550</td><td>HD 162989</td><td>Ref 1 deg F1550C</td><td>2299.49</td><td>9</td><td>1037</td><td>MIRI Coronagraphic Contrast Ratios</td><td>Boccaletti, Anthony</td></tr>\n",
+       "<tr><td>V01386007001</td><td>2022-07-17 20:48</td><td>F1550C</td><td>4QPM_1550</td><td>* phi Cen</td><td>MIRI 1550C - REF</td><td>459.706</td><td>9</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01045088001</td><td>2022-07-19 10:02</td><td>F1550C</td><td>4QPM_1550</td><td>HD 92209</td><td>4QPM - F1550C</td><td>2299.49</td><td>5</td><td>1045</td><td>MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition</td><td>Dicken, Daniel</td></tr>\n",
+       "<tr><td>V01386027001</td><td>2022-08-02 17:02</td><td>F1550C</td><td>4QPM_1550</td><td>HD 140986</td><td>MIRI F1550C - REF</td><td>1726.894</td><td>5</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01193004001</td><td>2022-10-21 18:48</td><td>F1550C</td><td>4QPM_1550</td><td>* 19 PsA</td><td>FomalhautPSF-1550C</td><td>202.29</td><td>9</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01194016001</td><td>2022-11-08 15:17</td><td>F1550C</td><td>4QPM_1550</td><td>HD 218261</td><td>REF 1550C</td><td>239.92</td><td>9</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01411008001</td><td>2022-12-13 08:54</td><td>F1550C</td><td>4QPM_1550</td><td>* alf Pic</td><td>Alpha Pic - 1550 4QPM PSF</td><td>725.991</td><td>5</td><td>1411</td><td>Coronagraphy of the Debris Disk Archetype Beta Pictoris</td><td>Stark, Chris</td></tr>\n",
+       "<tr><td>V01241041001</td><td>2023-03-10 19:02</td><td>F1550C</td><td>4QPM_1550</td><td>HD 49518</td><td>Ref HR 2562 - F1550C</td><td>357.123</td><td>5</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
+       "<tr><td>V02243006001</td><td>2023-07-03 14:08</td><td>F1550C</td><td>4QPM_1550</td><td>V* DI Tuc</td><td>DITuc F1550C</td><td>2724.443</td><td>5</td><td>2243</td><td>A direct detection of the closest Jupiter analog with JWST/MIRI</td><td>Matthews, Elisabeth C</td></tr>\n",
+       "<tr><td>V01413009001</td><td>2023-07-15 22:40</td><td>F1550C</td><td>4QPM_1550</td><td>HD 190360</td><td>HD 190360 F1550 (PSF star)</td><td>293.848</td><td>9</td><td>1413</td><td>MIRI coronagraphy of the Cold Substellar Companion GJ 758 B</td><td>Pueyo, Laurent</td></tr>\n",
+       "<tr><td>V01618007001</td><td>2023-07-27 04:34</td><td>F1550C</td><td>4QPM_1550</td><td>dr3-5859405804986931200</td><td>offset star for eps Mus. Position A. Obs 2</td><td>2971.792</td><td>9</td><td>1618</td><td>Searching Our  Closest Stellar  Neighbor for Planets and Zodiacal Emission</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01193024001</td><td>2023-08-18 21:39</td><td>F1550C</td><td>4QPM_1550</td><td>HD 169305</td><td>VegaPSF-1550C</td><td>206.844</td><td>9</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01241021001</td><td>2023-09-19 14:11</td><td>F1550C</td><td>4QPM_1550</td><td>HD 222389</td><td>Ref kappa And - F1550C</td><td>199.653</td><td>5</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
        "</table></div>"
       ],
       "text/plain": [
-       "<Table length=10>\n",
-       "  visit_id      start time    filter  kind   coronmsk  targname          obslabel         duration numdthpt program                                      title                                             pi_name       \n",
-       "   str12          str16        str6  bytes3    str9      str9             str25           float64   int64    int64                                       str80                                              str20        \n",
-       "------------ ---------------- ------ ------ --------- --------- ------------------------- -------- -------- ------- -------------------------------------------------------------------------------- --------------------\n",
-       "V01045069001 2022-06-13 17:35 F1550C    REF 4QPM_1550  HD 92209             4QPM - F1550C  774.406        9    1045 MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition       Dicken, Daniel\n",
-       "V01037010001 2022-06-18 15:04 F1550C    REF 4QPM_1550 HD 163113             4QPM - F1550C  2299.49        9    1037                                               MIRI Coronagraphic Contrast Ratios  Boccaletti, Anthony\n",
-       "V01037011001 2022-06-18 21:13 F1550C    REF 4QPM_1550 HD 162989          Ref 1 deg F1550C  2299.49        9    1037                                               MIRI Coronagraphic Contrast Ratios  Boccaletti, Anthony\n",
-       "V01386007001 2022-07-17 20:48 F1550C    REF 4QPM_1550 * phi Cen          MIRI 1550C - REF  459.706        9    1386           High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
-       "V01045088001 2022-07-19 10:02 F1550C    REF 4QPM_1550  HD 92209             4QPM - F1550C  2299.49        5    1045 MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition       Dicken, Daniel\n",
-       "V01386027001 2022-08-02 17:02 F1550C    REF 4QPM_1550 HD 140986         MIRI F1550C - REF 1726.894        5    1386           High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
-       "V01193004001 2022-10-21 18:48 F1550C    REF 4QPM_1550  * 19 PsA        FomalhautPSF-1550C   202.29        9    1193      Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
-       "V01194016001 2022-11-08 15:17 F1550C    REF 4QPM_1550 HD 218261                 REF 1550C   239.92        9    1194               Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
-       "V01411008001 2022-12-13 08:54 F1550C    REF 4QPM_1550 * alf Pic Alpha Pic - 1550 4QPM PSF  725.991        5    1411                          Coronagraphy of the Debris Disk Archetype Beta Pictoris         Stark, Chris\n",
-       "V01241041001 2023-03-10 19:02 F1550C    REF 4QPM_1550  HD 49518      Ref HR 2562 - F1550C  357.123        5    1241                                         MIRI Coronagraphic Imaging of exoplanets  Ressler, Michael E."
+       "<Table length=15>\n",
+       "  visit_id      start time    filter  coronmsk         targname        ... duration numdthpt program                                      title                                              pi_name       \n",
+       "   str12          str16        str6     str9            str23          ... float64   int64    int64                                       str80                                               str21        \n",
+       "------------ ---------------- ------ --------- ----------------------- ... -------- -------- ------- -------------------------------------------------------------------------------- ---------------------\n",
+       "V01045069001 2022-06-13 17:35 F1550C 4QPM_1550                HD 92209 ...  774.406        9    1045 MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition        Dicken, Daniel\n",
+       "V01037010001 2022-06-18 15:04 F1550C 4QPM_1550               HD 163113 ...  2299.49        9    1037                                               MIRI Coronagraphic Contrast Ratios   Boccaletti, Anthony\n",
+       "V01037011001 2022-06-18 21:13 F1550C 4QPM_1550               HD 162989 ...  2299.49        9    1037                                               MIRI Coronagraphic Contrast Ratios   Boccaletti, Anthony\n",
+       "V01386007001 2022-07-17 20:48 F1550C 4QPM_1550               * phi Cen ...  459.706        9    1386           High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST        Hinkley, Sasha\n",
+       "V01045088001 2022-07-19 10:02 F1550C 4QPM_1550                HD 92209 ...  2299.49        5    1045 MIRI Coronagraphic PSF Characterization, Radial Transmission and 4QPM Transition        Dicken, Daniel\n",
+       "V01386027001 2022-08-02 17:02 F1550C 4QPM_1550               HD 140986 ... 1726.894        5    1386           High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST        Hinkley, Sasha\n",
+       "V01193004001 2022-10-21 18:48 F1550C 4QPM_1550                * 19 PsA ...   202.29        9    1193      Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI  Beichman, Charles A.\n",
+       "V01194016001 2022-11-08 15:17 F1550C 4QPM_1550               HD 218261 ...   239.92        9    1194               Characterization of the HR 8799 planetary system and planet search  Beichman, Charles A.\n",
+       "V01411008001 2022-12-13 08:54 F1550C 4QPM_1550               * alf Pic ...  725.991        5    1411                          Coronagraphy of the Debris Disk Archetype Beta Pictoris          Stark, Chris\n",
+       "V01241041001 2023-03-10 19:02 F1550C 4QPM_1550                HD 49518 ...  357.123        5    1241                                         MIRI Coronagraphic Imaging of exoplanets   Ressler, Michael E.\n",
+       "V02243006001 2023-07-03 14:08 F1550C 4QPM_1550               V* DI Tuc ... 2724.443        5    2243                  A direct detection of the closest Jupiter analog with JWST/MIRI Matthews, Elisabeth C\n",
+       "V01413009001 2023-07-15 22:40 F1550C 4QPM_1550               HD 190360 ...  293.848        9    1413                      MIRI coronagraphy of the Cold Substellar Companion GJ 758 B        Pueyo, Laurent\n",
+       "V01618007001 2023-07-27 04:34 F1550C 4QPM_1550 dr3-5859405804986931200 ... 2971.792        9    1618       Searching Our  Closest Stellar  Neighbor for Planets and Zodiacal Emission  Beichman, Charles A.\n",
+       "V01193024001 2023-08-18 21:39 F1550C 4QPM_1550               HD 169305 ...  206.844        9    1193      Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI  Beichman, Charles A.\n",
+       "V01241021001 2023-09-19 14:11 F1550C 4QPM_1550               HD 222389 ...  199.653        5    1241                                         MIRI Coronagraphic Imaging of exoplanets   Ressler, Michael E."
       ]
      },
      "execution_count": 2,
@@ -205,43 +175,71 @@
     {
      "data": {
       "text/html": [
-       "<div><i>Table length=13</i>\n",
-       "<table id=\"table140685166977184\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>visit_id</th><th>start time</th><th>filter</th><th>kind</th><th>coronmsk</th><th>targname</th><th>obslabel</th><th>duration</th><th>numdthpt</th><th>program</th><th>title</th><th>pi_name</th></tr></thead>\n",
-       "<thead><tr><th>str12</th><th>str16</th><th>str6</th><th>bytes3</th><th>str9</th><th>str21</th><th>str36</th><th>float64</th><th>int64</th><th>int64</th><th>str75</th><th>str20</th></tr></thead>\n",
-       "<tr><td>V01386030001</td><td>2022-07-18 02:42</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>MIRI 1550C - Target BG</td><td>3609.341</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
-       "<tr><td>V01386031001</td><td>2022-07-18 04:53</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>MIRI 1550C - REF BG</td><td>459.706</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
-       "<tr><td>V01386036001</td><td>2022-08-02 19:57</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>MIRI F1550C - Target BG</td><td>3741.884</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
-       "<tr><td>V01386037001</td><td>2022-08-02 22:29</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>MIRI F1550C - REF BG</td><td>1726.894</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
-       "<tr><td>V01193005001</td><td>2022-10-21 19:43</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>* 19 PsA</td><td>FomalhautPSF-1550C-background</td><td>202.29</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01193010001</td><td>2022-10-21 22:42</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>FOMALHAUT-F1550C-BACK</td><td>Fomalhaut-F1550C-background</td><td>914.379</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01194011001</td><td>2022-11-08 10:18</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>1550C - Target Bkg</td><td>4322.629</td><td>2</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01194018001</td><td>2022-11-08 16:18</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>1550C - REF Bkg</td><td>239.92</td><td>2</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
-       "<tr><td>V01406030001</td><td>2022-11-29 05:12</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>HD 161617</td><td>1550-BGND</td><td>508.122</td><td>2</td><td>1406</td><td>Verification of the MIRI Coronagraphic Target Acquisition</td><td>Hines, Dean C.</td></tr>\n",
-       "<tr><td>V01411001001</td><td>2022-12-13 00:10</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>Beta Pic Background - 1550 4QPM</td><td>1331.183</td><td>2</td><td>1411</td><td>Coronagraphy of the Debris Disk Archetype Beta Pictoris</td><td>Stark, Chris</td></tr>\n",
-       "<tr><td>V01411009001</td><td>2022-12-13 10:17</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>N/A</td><td>Alpha Pic Background - 1550 4QPM PSF</td><td>725.991</td><td>2</td><td>1411</td><td>Coronagraphy of the Debris Disk Archetype Beta Pictoris</td><td>Stark, Chris</td></tr>\n",
-       "<tr><td>V01241033001</td><td>2023-03-10 15:05</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>HR 2562 Background</td><td>HR 2562 Bckgr - F1550C</td><td>1199.119</td><td>2</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
-       "<tr><td>V01241044001</td><td>2023-03-10 20:22</td><td>F1550C</td><td>BKG</td><td>4QPM_1550</td><td>HD 49518 Background</td><td>Ref HR 2562 Bckgr - F1550C</td><td>357.123</td><td>2</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
+       "<div><i>Table length=27</i>\n",
+       "<table id=\"table11262328784\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>visit_id</th><th>start time</th><th>filter</th><th>coronmsk</th><th>targname</th><th>obslabel</th><th>duration</th><th>numdthpt</th><th>program</th><th>title</th><th>pi_name</th></tr></thead>\n",
+       "<thead><tr><th>str12</th><th>str16</th><th>str6</th><th>str9</th><th>str21</th><th>str37</th><th>float64</th><th>int64</th><th>int64</th><th>str91</th><th>str22</th></tr></thead>\n",
+       "<tr><td>V01386030001</td><td>2022-07-18 02:42</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>MIRI 1550C - Target BG</td><td>3609.341</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386031001</td><td>2022-07-18 04:53</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>MIRI 1550C - REF BG</td><td>459.706</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386036001</td><td>2022-08-02 19:57</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>MIRI F1550C - Target BG</td><td>3741.884</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386037001</td><td>2022-08-02 22:29</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>MIRI F1550C - REF BG</td><td>1726.894</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01193005001</td><td>2022-10-21 19:43</td><td>F1550C</td><td>4QPM_1550</td><td>* 19 PsA</td><td>FomalhautPSF-1550C-background</td><td>202.29</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01193010001</td><td>2022-10-21 22:42</td><td>F1550C</td><td>4QPM_1550</td><td>FOMALHAUT-F1550C-BACK</td><td>Fomalhaut-F1550C-background</td><td>914.379</td><td>1</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01194011001</td><td>2022-11-08 10:18</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>1550C - Target Bkg</td><td>4322.629</td><td>2</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01194018001</td><td>2022-11-08 16:18</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>1550C - REF Bkg</td><td>239.92</td><td>2</td><td>1194</td><td>Characterization of the HR 8799 planetary system and planet search</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01406030001</td><td>2022-11-29 05:12</td><td>F1550C</td><td>4QPM_1550</td><td>HD 161617</td><td>1550-BGND</td><td>508.122</td><td>2</td><td>1406</td><td>Verification of the MIRI Coronagraphic Target Acquisition</td><td>Hines, Dean C.</td></tr>\n",
+       "<tr><td>V01411001001</td><td>2022-12-13 00:10</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>Beta Pic Background - 1550 4QPM</td><td>1331.183</td><td>2</td><td>1411</td><td>Coronagraphy of the Debris Disk Archetype Beta Pictoris</td><td>Stark, Chris</td></tr>\n",
+       "<tr><td>V01411009001</td><td>2022-12-13 10:17</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>Alpha Pic Background - 1550 4QPM PSF</td><td>725.991</td><td>2</td><td>1411</td><td>Coronagraphy of the Debris Disk Archetype Beta Pictoris</td><td>Stark, Chris</td></tr>\n",
+       "<tr><td>V01241033001</td><td>2023-03-10 15:05</td><td>F1550C</td><td>4QPM_1550</td><td>HR 2562 Background</td><td>HR 2562 Bckgr - F1550C</td><td>1199.119</td><td>2</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
+       "<tr><td>V01241044001</td><td>2023-03-10 20:22</td><td>F1550C</td><td>4QPM_1550</td><td>HD 49518 Background</td><td>Ref HR 2562 Bckgr - F1550C</td><td>357.123</td><td>2</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
+       "<tr><td>V01277021001</td><td>2023-05-16 20:26</td><td>F1550C</td><td>4QPM_1550</td><td>HD 106906 background</td><td>HD106906 Bkg 1500C</td><td>960.398</td><td>2</td><td>1277</td><td>Coronographic Observations of Young Exoplanets and Spectroscopic Observations of ROSS 458 C</td><td>Lagage, Pierre-Olivier</td></tr>\n",
+       "<tr><td>V02243001001</td><td>2023-07-03 00:54</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>BG_dituc F1550C</td><td>2724.443</td><td>2</td><td>2243</td><td>A direct detection of the closest Jupiter analog with JWST/MIRI</td><td>Matthews, Elisabeth C</td></tr>\n",
+       "<tr><td>V02243002001</td><td>2023-07-03 03:33</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>BG_epsindi F1550C</td><td>3922.363</td><td>2</td><td>2243</td><td>A direct detection of the closest Jupiter analog with JWST/MIRI</td><td>Matthews, Elisabeth C</td></tr>\n",
+       "<tr><td>V01277016001</td><td>2023-07-04 12:41</td><td>F1550C</td><td>4QPM_1550</td><td>GJ 504 background</td><td>GJ504 Bkg 1550C</td><td>239.92</td><td>2</td><td>1277</td><td>Coronographic Observations of Young Exoplanets and Spectroscopic Observations of ROSS 458 C</td><td>Lagage, Pierre-Olivier</td></tr>\n",
+       "<tr><td>V01413004001</td><td>2023-07-15 18:41</td><td>F1550C</td><td>4QPM_1550</td><td>GJ-758-Background</td><td>GJ 758 F1550 roll 1 BACKGROUND</td><td>864.046</td><td>2</td><td>1413</td><td>MIRI coronagraphy of the Cold Substellar Companion GJ 758 B</td><td>Pueyo, Laurent</td></tr>\n",
+       "<tr><td>V01413010001</td><td>2023-07-15 23:49</td><td>F1550C</td><td>4QPM_1550</td><td>HD-190360-BACKGROUND</td><td>HD 190360 F1550 (PSF star) BACKGROUND</td><td>293.848</td><td>2</td><td>1413</td><td>MIRI coronagraphy of the Cold Substellar Companion GJ 758 B</td><td>Pueyo, Laurent</td></tr>\n",
+       "<tr><td>V01618002001</td><td>2023-07-26 08:51</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>eps Mus Position A  BACKGROUND</td><td>2971.792</td><td>2</td><td>1618</td><td>Searching Our  Closest Stellar  Neighbor for Planets and Zodiacal Emission</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01618004001</td><td>2023-07-26 14:18</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>Alpha Cen A F1550 - BACKGROUND</td><td>9287.36</td><td>2</td><td>1618</td><td>Searching Our  Closest Stellar  Neighbor for Planets and Zodiacal Emission</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01618006001</td><td>2023-07-26 23:00</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>Alpha Cen A F1550  - BACKGROUND</td><td>9287.36</td><td>2</td><td>1618</td><td>Searching Our  Closest Stellar  Neighbor for Planets and Zodiacal Emission</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01618008001</td><td>2023-07-27 12:52</td><td>F1550C</td><td>4QPM_1550</td><td>N/A</td><td>offset star for eps Mus.   BACKGROUND</td><td>2971.792</td><td>2</td><td>1618</td><td>Searching Our  Closest Stellar  Neighbor for Planets and Zodiacal Emission</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01193025001</td><td>2023-08-18 22:39</td><td>F1550C</td><td>4QPM_1550</td><td>HD 169305</td><td>VegaPSF-1550C-background</td><td>206.844</td><td>2</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01193030001</td><td>2023-08-19 02:01</td><td>F1550C</td><td>4QPM_1550</td><td>VEGA-F1550C-BACK</td><td>Vega-1550C-background</td><td>915.817</td><td>2</td><td>1193</td><td>Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI</td><td>Beichman, Charles A.</td></tr>\n",
+       "<tr><td>V01241013001</td><td>2023-09-19 10:25</td><td>F1550C</td><td>4QPM_1550</td><td>kappa And Background</td><td>kappa And Bckgr - F1550C</td><td>899.279</td><td>2</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
+       "<tr><td>V01241024001</td><td>2023-09-19 15:22</td><td>F1550C</td><td>4QPM_1550</td><td>HD 222389 Background</td><td>Ref kappa And Bckgr - F1550C</td><td>199.653</td><td>2</td><td>1241</td><td>MIRI Coronagraphic Imaging of exoplanets</td><td>Ressler, Michael E.</td></tr>\n",
        "</table></div>"
       ],
       "text/plain": [
-       "<Table length=13>\n",
-       "  visit_id      start time    filter  kind   coronmsk        targname                     obslabel               duration numdthpt program                                    title                                          pi_name       \n",
-       "   str12          str16        str6  bytes3    str9           str21                        str36                 float64   int64    int64                                     str75                                           str20        \n",
-       "------------ ---------------- ------ ------ --------- --------------------- ------------------------------------ -------- -------- ------- --------------------------------------------------------------------------- --------------------\n",
-       "V01386030001 2022-07-18 02:42 F1550C    BKG 4QPM_1550                   N/A               MIRI 1550C - Target BG 3609.341        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
-       "V01386031001 2022-07-18 04:53 F1550C    BKG 4QPM_1550                   N/A                  MIRI 1550C - REF BG  459.706        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
-       "V01386036001 2022-08-02 19:57 F1550C    BKG 4QPM_1550                   N/A              MIRI F1550C - Target BG 3741.884        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
-       "V01386037001 2022-08-02 22:29 F1550C    BKG 4QPM_1550                   N/A                 MIRI F1550C - REF BG 1726.894        1    1386      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST       Hinkley, Sasha\n",
-       "V01193005001 2022-10-21 19:43 F1550C    BKG 4QPM_1550              * 19 PsA        FomalhautPSF-1550C-background   202.29        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
-       "V01193010001 2022-10-21 22:42 F1550C    BKG 4QPM_1550 FOMALHAUT-F1550C-BACK          Fomalhaut-F1550C-background  914.379        1    1193 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI Beichman, Charles A.\n",
-       "V01194011001 2022-11-08 10:18 F1550C    BKG 4QPM_1550                   N/A                   1550C - Target Bkg 4322.629        2    1194          Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
-       "V01194018001 2022-11-08 16:18 F1550C    BKG 4QPM_1550                   N/A                      1550C - REF Bkg   239.92        2    1194          Characterization of the HR 8799 planetary system and planet search Beichman, Charles A.\n",
-       "V01406030001 2022-11-29 05:12 F1550C    BKG 4QPM_1550             HD 161617                            1550-BGND  508.122        2    1406                   Verification of the MIRI Coronagraphic Target Acquisition       Hines, Dean C.\n",
-       "V01411001001 2022-12-13 00:10 F1550C    BKG 4QPM_1550                   N/A      Beta Pic Background - 1550 4QPM 1331.183        2    1411                     Coronagraphy of the Debris Disk Archetype Beta Pictoris         Stark, Chris\n",
-       "V01411009001 2022-12-13 10:17 F1550C    BKG 4QPM_1550                   N/A Alpha Pic Background - 1550 4QPM PSF  725.991        2    1411                     Coronagraphy of the Debris Disk Archetype Beta Pictoris         Stark, Chris\n",
-       "V01241033001 2023-03-10 15:05 F1550C    BKG 4QPM_1550    HR 2562 Background               HR 2562 Bckgr - F1550C 1199.119        2    1241                                    MIRI Coronagraphic Imaging of exoplanets  Ressler, Michael E.\n",
-       "V01241044001 2023-03-10 20:22 F1550C    BKG 4QPM_1550   HD 49518 Background           Ref HR 2562 Bckgr - F1550C  357.123        2    1241                                    MIRI Coronagraphic Imaging of exoplanets  Ressler, Michael E."
+       "<Table length=27>\n",
+       "  visit_id      start time    filter  coronmsk        targname       ... duration numdthpt program                                            title                                                   pi_name        \n",
+       "   str12          str16        str6     str9           str21         ... float64   int64    int64                                             str91                                                    str22         \n",
+       "------------ ---------------- ------ --------- --------------------- ... -------- -------- ------- ------------------------------------------------------------------------------------------- ----------------------\n",
+       "V01386030001 2022-07-18 02:42 F1550C 4QPM_1550                   N/A ... 3609.341        1    1386                      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST         Hinkley, Sasha\n",
+       "V01386031001 2022-07-18 04:53 F1550C 4QPM_1550                   N/A ...  459.706        1    1386                      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST         Hinkley, Sasha\n",
+       "V01386036001 2022-08-02 19:57 F1550C 4QPM_1550                   N/A ... 3741.884        1    1386                      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST         Hinkley, Sasha\n",
+       "V01386037001 2022-08-02 22:29 F1550C 4QPM_1550                   N/A ... 1726.894        1    1386                      High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST         Hinkley, Sasha\n",
+       "V01193005001 2022-10-21 19:43 F1550C 4QPM_1550              * 19 PsA ...   202.29        1    1193                 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI   Beichman, Charles A.\n",
+       "V01193010001 2022-10-21 22:42 F1550C 4QPM_1550 FOMALHAUT-F1550C-BACK ...  914.379        1    1193                 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI   Beichman, Charles A.\n",
+       "V01194011001 2022-11-08 10:18 F1550C 4QPM_1550                   N/A ... 4322.629        2    1194                          Characterization of the HR 8799 planetary system and planet search   Beichman, Charles A.\n",
+       "V01194018001 2022-11-08 16:18 F1550C 4QPM_1550                   N/A ...   239.92        2    1194                          Characterization of the HR 8799 planetary system and planet search   Beichman, Charles A.\n",
+       "V01406030001 2022-11-29 05:12 F1550C 4QPM_1550             HD 161617 ...  508.122        2    1406                                   Verification of the MIRI Coronagraphic Target Acquisition         Hines, Dean C.\n",
+       "V01411001001 2022-12-13 00:10 F1550C 4QPM_1550                   N/A ... 1331.183        2    1411                                     Coronagraphy of the Debris Disk Archetype Beta Pictoris           Stark, Chris\n",
+       "V01411009001 2022-12-13 10:17 F1550C 4QPM_1550                   N/A ...  725.991        2    1411                                     Coronagraphy of the Debris Disk Archetype Beta Pictoris           Stark, Chris\n",
+       "V01241033001 2023-03-10 15:05 F1550C 4QPM_1550    HR 2562 Background ... 1199.119        2    1241                                                    MIRI Coronagraphic Imaging of exoplanets    Ressler, Michael E.\n",
+       "V01241044001 2023-03-10 20:22 F1550C 4QPM_1550   HD 49518 Background ...  357.123        2    1241                                                    MIRI Coronagraphic Imaging of exoplanets    Ressler, Michael E.\n",
+       "V01277021001 2023-05-16 20:26 F1550C 4QPM_1550  HD 106906 background ...  960.398        2    1277 Coronographic Observations of Young Exoplanets and Spectroscopic Observations of ROSS 458 C Lagage, Pierre-Olivier\n",
+       "V02243001001 2023-07-03 00:54 F1550C 4QPM_1550                   N/A ... 2724.443        2    2243                             A direct detection of the closest Jupiter analog with JWST/MIRI  Matthews, Elisabeth C\n",
+       "V02243002001 2023-07-03 03:33 F1550C 4QPM_1550                   N/A ... 3922.363        2    2243                             A direct detection of the closest Jupiter analog with JWST/MIRI  Matthews, Elisabeth C\n",
+       "V01277016001 2023-07-04 12:41 F1550C 4QPM_1550     GJ 504 background ...   239.92        2    1277 Coronographic Observations of Young Exoplanets and Spectroscopic Observations of ROSS 458 C Lagage, Pierre-Olivier\n",
+       "V01413004001 2023-07-15 18:41 F1550C 4QPM_1550     GJ-758-Background ...  864.046        2    1413                                 MIRI coronagraphy of the Cold Substellar Companion GJ 758 B         Pueyo, Laurent\n",
+       "V01413010001 2023-07-15 23:49 F1550C 4QPM_1550  HD-190360-BACKGROUND ...  293.848        2    1413                                 MIRI coronagraphy of the Cold Substellar Companion GJ 758 B         Pueyo, Laurent\n",
+       "V01618002001 2023-07-26 08:51 F1550C 4QPM_1550                   N/A ... 2971.792        2    1618                  Searching Our  Closest Stellar  Neighbor for Planets and Zodiacal Emission   Beichman, Charles A.\n",
+       "V01618004001 2023-07-26 14:18 F1550C 4QPM_1550                   N/A ...  9287.36        2    1618                  Searching Our  Closest Stellar  Neighbor for Planets and Zodiacal Emission   Beichman, Charles A.\n",
+       "V01618006001 2023-07-26 23:00 F1550C 4QPM_1550                   N/A ...  9287.36        2    1618                  Searching Our  Closest Stellar  Neighbor for Planets and Zodiacal Emission   Beichman, Charles A.\n",
+       "V01618008001 2023-07-27 12:52 F1550C 4QPM_1550                   N/A ... 2971.792        2    1618                  Searching Our  Closest Stellar  Neighbor for Planets and Zodiacal Emission   Beichman, Charles A.\n",
+       "V01193025001 2023-08-18 22:39 F1550C 4QPM_1550             HD 169305 ...  206.844        2    1193                 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI   Beichman, Charles A.\n",
+       "V01193030001 2023-08-19 02:01 F1550C 4QPM_1550      VEGA-F1550C-BACK ...  915.817        2    1193                 Coronagraphic Imaging of Young Planets and Debris Disk with NIRCam and MIRI   Beichman, Charles A.\n",
+       "V01241013001 2023-09-19 10:25 F1550C 4QPM_1550  kappa And Background ...  899.279        2    1241                                                    MIRI Coronagraphic Imaging of exoplanets    Ressler, Michael E.\n",
+       "V01241024001 2023-09-19 15:22 F1550C 4QPM_1550  HD 222389 Background ...  199.653        2    1241                                                    MIRI Coronagraphic Imaging of exoplanets    Ressler, Michael E."
       ]
      },
      "execution_count": 3,
@@ -254,9 +252,202 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cf8b3634",
+   "metadata": {},
+   "source": [
+    "### Available search keywords"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ac9739dd",
+   "metadata": {},
+   "source": [
+    "You can also query by program ID number, filter, coronagraph mask name, and for NIRCam also channel name SW/LW."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "949560b2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table length=2</i>\n",
+       "<table id=\"table11189744208\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>visit_id</th><th>start time</th><th>filter</th><th>coronmsk</th><th>targname</th><th>obslabel</th><th>duration</th><th>numdthpt</th><th>program</th><th>title</th><th>pi_name</th></tr></thead>\n",
+       "<thead><tr><th>str12</th><th>str16</th><th>str5</th><th>str9</th><th>str9</th><th>str20</th><th>float64</th><th>int64</th><th>int64</th><th>str70</th><th>str14</th></tr></thead>\n",
+       "<tr><td>V01386002001</td><td>2022-07-30 01:13</td><td>F444W</td><td>MASKA335R</td><td>HD 116434</td><td>NIRCam 335R - Roll 1</td><td>617.946</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "<tr><td>V01386003001</td><td>2022-07-30 03:16</td><td>F444W</td><td>MASKA335R</td><td>HD 116434</td><td>NIRCam 335R - Roll 2</td><td>617.946</td><td>1</td><td>1386</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>Hinkley, Sasha</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table length=2>\n",
+       "  visit_id      start time    filter  coronmsk  targname       obslabel       duration numdthpt program                                 title                                     pi_name    \n",
+       "   str12          str16        str5     str9      str9          str20         float64   int64    int64                                  str70                                      str14     \n",
+       "------------ ---------------- ------ --------- --------- -------------------- -------- -------- ------- ---------------------------------------------------------------------- --------------\n",
+       "V01386002001 2022-07-30 01:13  F444W MASKA335R HD 116434 NIRCam 335R - Roll 1  617.946        1    1386 High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST Hinkley, Sasha\n",
+       "V01386003001 2022-07-30 03:16  F444W MASKA335R HD 116434 NIRCam 335R - Roll 2  617.946        1    1386 High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST Hinkley, Sasha"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spaceKLIP.mast.query_coron_datasets('NIRCam', program=1386, filt='F444W', kind='SCI')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "403e6350",
+   "metadata": {},
+   "source": [
+    "## Retrieving filenames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f78cb94b",
+   "metadata": {},
+   "source": [
+    "Note that the above by default *does not return filenames*, nor indeed individual exposures. Each row summarizes one observation, even though there are often multiple dithered exposures per observation. \n",
+    "\n",
+    "Set the `return_filenames` option to return filenames. This will also return more exhaustive metadata in additional table columns as well, compared to the default shorter summary output. \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5d9315e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table masked=True length=2</i>\n",
+       "<table id=\"table11268839568\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>filename</th><th>productLevel</th><th>kind</th><th>filter</th><th>coronmsk</th><th>targname</th><th>duration</th><th>effexptm</th><th>effinttm</th><th>exp_type</th><th>bkgdtarg</th><th>bstrtime</th><th>is_psf</th><th>nexposur</th><th>nframes</th><th>nints</th><th>numdthpt</th><th>obs_id</th><th>obslabel</th><th>pi_name</th><th>program</th><th>subarray</th><th>template</th><th>title</th><th>visit_id</th><th>visitsta</th><th>vststart_mjd</th><th>isRestricted</th></tr></thead>\n",
+       "<thead><tr><th>str47</th><th>str2</th><th>bytes3</th><th>str5</th><th>str9</th><th>str9</th><th>float64</th><th>float64</th><th>float64</th><th>str9</th><th>str1</th><th>float64</th><th>str1</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>str26</th><th>str20</th><th>str14</th><th>int64</th><th>str11</th><th>str28</th><th>str70</th><th>str12</th><th>str10</th><th>float64</th><th>bool</th></tr></thead>\n",
+       "<tr><td>jw01386002001_0310a_00001_nrcalong_calints.fits</td><td>2b</td><td>SCI</td><td>F444W</td><td>MASKA335R</td><td>HD 116434</td><td>617.946</td><td>615.767</td><td>307.88352</td><td>NRC_CORON</td><td>f</td><td>59790.1298299529</td><td>f</td><td>8</td><td>8</td><td>2</td><td>1</td><td>V01386002001P000000000310A</td><td>NIRCam 335R - Roll 1</td><td>Hinkley, Sasha</td><td>1386</td><td>SUB320A335R</td><td>NIRCam Coronagraphic Imaging</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>V01386002001</td><td>SUCCESSFUL</td><td>59790.05121913194</td><td>False</td></tr>\n",
+       "<tr><td>jw01386003001_0310a_00001_nrcalong_calints.fits</td><td>2b</td><td>SCI</td><td>F444W</td><td>MASKA335R</td><td>HD 116434</td><td>617.946</td><td>615.767</td><td>307.88352</td><td>NRC_CORON</td><td>f</td><td>59790.21375087909</td><td>f</td><td>8</td><td>8</td><td>2</td><td>1</td><td>V01386003001P000000000310A</td><td>NIRCam 335R - Roll 2</td><td>Hinkley, Sasha</td><td>1386</td><td>SUB320A335R</td><td>NIRCam Coronagraphic Imaging</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>V01386003001</td><td>SUCCESSFUL</td><td>59790.13650497685</td><td>False</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table masked=True length=2>\n",
+       "                    filename                    productLevel  kind  filter  coronmsk ...                                 title                                    visit_id    visitsta     vststart_mjd   isRestricted\n",
+       "                     str47                          str2     bytes3  str5     str9   ...                                 str70                                     str12       str10         float64          bool    \n",
+       "----------------------------------------------- ------------ ------ ------ --------- ... ---------------------------------------------------------------------- ------------ ---------- ----------------- ------------\n",
+       "jw01386002001_0310a_00001_nrcalong_calints.fits           2b    SCI  F444W MASKA335R ... High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST V01386002001 SUCCESSFUL 59790.05121913194        False\n",
+       "jw01386003001_0310a_00001_nrcalong_calints.fits           2b    SCI  F444W MASKA335R ... High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST V01386003001 SUCCESSFUL 59790.13650497685        False"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spaceKLIP.mast.query_coron_datasets('NIRCam', program=1386, filt='F444W', kind='SCI', return_filenames=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3e97d30",
+   "metadata": {},
+   "source": [
+    "Set the `level` option to `uncal` or `rate` if you want the filenames for those data products instead. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "56fa7627",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><i>Table masked=True length=2</i>\n",
+       "<table id=\"table11267853264\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>filename</th><th>productLevel</th><th>kind</th><th>filter</th><th>coronmsk</th><th>targname</th><th>duration</th><th>effexptm</th><th>effinttm</th><th>exp_type</th><th>bkgdtarg</th><th>bstrtime</th><th>is_psf</th><th>nexposur</th><th>nframes</th><th>nints</th><th>numdthpt</th><th>obs_id</th><th>obslabel</th><th>pi_name</th><th>program</th><th>subarray</th><th>template</th><th>title</th><th>visit_id</th><th>visitsta</th><th>vststart_mjd</th><th>isRestricted</th></tr></thead>\n",
+       "<thead><tr><th>str45</th><th>str2</th><th>bytes3</th><th>str5</th><th>str9</th><th>str9</th><th>float64</th><th>float64</th><th>float64</th><th>str9</th><th>str1</th><th>float64</th><th>str1</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>str26</th><th>str20</th><th>str14</th><th>int64</th><th>str11</th><th>str28</th><th>str70</th><th>str12</th><th>str10</th><th>float64</th><th>bool</th></tr></thead>\n",
+       "<tr><td>jw01386002001_0310a_00001_nrcalong_uncal.fits</td><td>1b</td><td>SCI</td><td>F444W</td><td>MASKA335R</td><td>HD 116434</td><td>617.946</td><td>615.767</td><td>307.88352</td><td>NRC_CORON</td><td>f</td><td>59790.1298299529</td><td>f</td><td>8</td><td>8</td><td>2</td><td>1</td><td>V01386002001P000000000310A</td><td>NIRCam 335R - Roll 1</td><td>Hinkley, Sasha</td><td>1386</td><td>SUB320A335R</td><td>NIRCam Coronagraphic Imaging</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>V01386002001</td><td>SUCCESSFUL</td><td>59790.05121913194</td><td>False</td></tr>\n",
+       "<tr><td>jw01386003001_0310a_00001_nrcalong_uncal.fits</td><td>1b</td><td>SCI</td><td>F444W</td><td>MASKA335R</td><td>HD 116434</td><td>617.946</td><td>615.767</td><td>307.88352</td><td>NRC_CORON</td><td>f</td><td>59790.21375087909</td><td>f</td><td>8</td><td>8</td><td>2</td><td>1</td><td>V01386003001P000000000310A</td><td>NIRCam 335R - Roll 2</td><td>Hinkley, Sasha</td><td>1386</td><td>SUB320A335R</td><td>NIRCam Coronagraphic Imaging</td><td>High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST</td><td>V01386003001</td><td>SUCCESSFUL</td><td>59790.13650497685</td><td>False</td></tr>\n",
+       "</table></div>"
+      ],
+      "text/plain": [
+       "<Table masked=True length=2>\n",
+       "                   filename                   productLevel  kind  filter  coronmsk ...                                 title                                    visit_id    visitsta     vststart_mjd   isRestricted\n",
+       "                    str45                         str2     bytes3  str5     str9   ...                                 str70                                     str12       str10         float64          bool    \n",
+       "--------------------------------------------- ------------ ------ ------ --------- ... ---------------------------------------------------------------------- ------------ ---------- ----------------- ------------\n",
+       "jw01386002001_0310a_00001_nrcalong_uncal.fits           1b    SCI  F444W MASKA335R ... High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST V01386002001 SUCCESSFUL 59790.05121913194        False\n",
+       "jw01386003001_0310a_00001_nrcalong_uncal.fits           1b    SCI  F444W MASKA335R ... High Contrast Imaging of Exoplanets and Exoplanetary Systems with JWST V01386003001 SUCCESSFUL 59790.13650497685        False"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spaceKLIP.mast.query_coron_datasets('NIRCam', program=1386, filt='F444W', kind='SCI', return_filenames=True,\n",
+    "                                    level='uncal')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f93d217c",
+   "metadata": {},
+   "source": [
+    "## Downloading data\n",
+    "\n",
+    "The `download_files` function can be used to download from MAST the filenames in a given query results table. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "2d7c9a73",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " DOWNLOAD SUCCESSFUL: ./jw01386002001_0310a_00001_nrcalong_uncal.fits\n",
+      " DOWNLOAD SUCCESSFUL: ./jw01386003001_0310a_00001_nrcalong_uncal.fits\n"
+     ]
+    }
+   ],
+   "source": [
+    "table = spaceKLIP.mast.query_coron_datasets('NIRCam', program=1386, filt='F444W', kind='SCI', return_filenames=True,\n",
+    "                                    level='uncal')\n",
+    "\n",
+    "spaceKLIP.mast.download_files(table)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f19b3059",
+   "metadata": {},
+   "source": [
+    "A MAST API token can be provided by the environment variable $MAST_API_TOKEN to enable download of exclusive-access data. \n",
+    "\n",
+    "Set the `outputdir` parameter if you want the files downloaded somewhere other then the current working directory. \n",
+    "\n",
+    "If the files already have been downloaded, they will by default be ignored. Set `overwrite=True` to redownload, or\n",
+    "`exists_ok=False` to raise an exception if such files already exist. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb6ac4c5",
+   "id": "dddfecf5",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -278,7 +469,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/spaceKLIP/mast.py
+++ b/spaceKLIP/mast.py
@@ -1,24 +1,14 @@
-from __future__ import division
-
-import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
-
 # =============================================================================
 # IMPORTS
 # =============================================================================
 
 import os
-import pdb
-import sys
 
-import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
-import astropy
-import astroquery
+import astropy, astropy.table
 from astroquery.mast import Mast
+import requests
 
 import logging
 log = logging.getLogger(__name__)
@@ -32,19 +22,27 @@ log.setLevel(logging.INFO)
 def set_params(parameters):
     """
     Utility function for making dicts used in MAST queries.
-    
+
     """
-    
+
     return [{'paramName': p, 'values': v} for p, v in parameters.items()]
 
+
 def query_coron_datasets(inst,
-                         filt,
+                         filt=None,
                          mask=None,
                          kind=None,
-                         ignore_cal=True):
+                         program=None,
+                         obsnum=None,
+                         channel=None,
+                         ignore_cal=True,
+                         ignore_ta=True,
+                         verbose=False,
+                         level=None,
+                         return_filenames=False):
     """
     Query MAST to make a summary table of existing JWST coronagraphic datasets.
-    
+
     Parameters
     ----------
     inst : str
@@ -60,18 +58,34 @@ def query_coron_datasets(inst,
     kind : str
         'SCI' for science targets, 'REF' for PSF references, or 'BKG' for
         backgrounds.
+    channel : str
+        For NIRCam only, channel name, "SW" or "SHORT" versus "LW" or "LONG".
+        Leave blank for both.
+    ignore_ta : bool
+        Ignore/exclude any target acquisition exposures. This can be
+        useful to only include science and reference images.
     ignore_cal : bool
         Ignore/exclude any category='CAL' calibration programs. This can be
         desirable to ignore the NIRCam coronagraphic flux calibration data
         sets, which otherwise look like science data to this query (programs
         1537 and 1538 for example).
-    
+    return_filenames : bool
+        Return a shorter summary table of observations, versus returning a
+        more comprehensive longer table of individual exposures and filenames?
+    level : str
+        Desired JWST data product level for filenames.
+        '1b' or 'uncal', '2a' or 'rate', etc.
+        For historical reasons it's not possible to easily query MAST directly for
+        products earlier than level 2b (cal/calints); MAST "hides" lower level files
+        once higher level products are available. Thus this works by querying for the
+        level 2b products, and performing filename transformation on them
+
     Returns
     -------
     None.
-    
+
     """
-    
+
     # Perform MAST query to find all available datasets for a given
     # filter/occulter.
     if inst.upper() == 'MIRI':
@@ -80,70 +94,214 @@ def query_coron_datasets(inst,
     else:
         service = 'Mast.Jwst.Filtered.NIRCam'
         template = 'NIRCam Coronagraphic Imaging'
-    
+
     keywords = {
-        'filter': [filt],
         'template': [template],
         'productLevel': ['2b'],
     }
-    
+    if filt is not None:
+        keywords['filter'] = [filt,]
+    if obsnum is not None:
+        keywords['observtn'] = obsnum if isinstance(obsnum, list) else [obsnum,]
+        keywords['observtn'] = [str(a) for a in keywords['observtn']] # must be string type!
+
     if mask is not None:
         keywords['coronmsk'] = [mask]
     if ignore_cal:
         keywords['category'] = ['COM', 'ERS', 'GTO', 'GO']  # but not CAL
-    
+    if ignore_ta:
+        keywords['exp_type'] = ['NRC_CORON', 'MIR_LYOT', 'MIR_4QPM']  # but not NRC_TACQ or MIRI_TACQ or NRC_TACONFIRM
+
+    # Optional, restrict to one apt program
+    if program is not None:
+        keywords['program'] = [f'{program:05d}',]
+
     # Optional, restrict to one kind of coronagraphic data
-    if kind == 'SCI':
-        keywords['is_psf'] = ['f']
-        keywords['bkgdtarg'] = ['f']
-    elif kind == 'REF':
-        keywords['is_psf'] = ['t']
-        keywords['bkgdtarg'] = ['f']
-    elif kind == 'BKG':
-        keywords['is_psf'] = ['f']
-        keywords['bkgdtarg'] = ['t']
-    
+    if kind is not None:
+        if kind.upper() == 'SCI':
+            keywords['is_psf'] = ['f']
+            keywords['bkgdtarg'] = ['f']
+        elif kind.upper() == 'REF':
+            keywords['is_psf'] = ['t']
+            keywords['bkgdtarg'] = ['f']
+        elif kind.upper() == 'BKG':
+            keywords['is_psf'] = ['f']
+            keywords['bkgdtarg'] = ['t']
+
+    if inst.upper()=='NIRCAM' and channel is not None:
+        if channel.upper().startswith('S'):
+            keywords['channel'] = ['SHORT',]
+        elif channel.upper().startswith('L'):
+            keywords['channel'] = ['LONG', ]
+        else:
+            raise RuntimeError("Invalid channel")
+
     # Method note: we query MAST for much more than we actually need/want, and
-    # then filter down afterwards. This is not entirely necessary, but leaves
+    # then filter down afterward. This is not entirely necessary, but leaves
     # room for future expansion to add options for more verbose output, etc.
-    # Currently this works by retrieving all level2b (i.e., cal/calints)
+    # Currently, this works by retrieving all level2b (i.e., cal/calints)
     # files, including all dithers etc., and then trimming to one unique row
     # per observation.
-    collist = 'filename, productLevel, bkgdtarg, bstrtime, duration, effexptm, effinttm, exp_type, filter, coronmsk, is_psf, nexposur, nframes, nints, numdthpt, obs_id, obslabel, pi_name, program, subarray, targname, template, title, visit_id, visitsta, vststart_mjd, isRestricted'
+    collist = 'filename, productLevel, filter, coronmsk, targname, duration, effexptm, effinttm, exp_type, bkgdtarg, bstrtime, is_psf, nexposur, nframes, nints, numdthpt, obs_id, obslabel, pi_name, program, subarray, template, title, visit_id, visitsta, vststart_mjd, isRestricted'
     all_columns = False
-    
+
     parameters = {'columns': '*' if all_columns else collist,
                   'filters': set_params(keywords)}
-    
-    response = Mast.service_request(service, parameters)
-    response.sort(keys='bstrtime')
-    
+    if verbose:
+        print("MAST query parameters:")
+        print(parameters)
+
+    responsetable = Mast.service_request(service, parameters)
+    responsetable.sort(keys='bstrtime')
+
+
+    # Add the initial V to visit ID.
+    responsetable['visit_id'] = astropy.table.Column(responsetable['visit_id'], dtype=np.dtype('<U12'))
+    for row in responsetable:
+        row['visit_id'] = 'V' + row['visit_id']
+
+    # Add a summary for which kind of observation each is.
+    kind = np.zeros(len(responsetable), dtype='a3')
+    kind[:] = 'SCI'  # by default assume SCI, then check for REF and BKG and TA
+    kind[responsetable.columns['is_psf'] == 't'] = 'REF'
+    kind[responsetable.columns['bkgdtarg'] == 't'] = 'BKG'
+    for ta_type in ['NRC_TACQ', 'NRC_TACONFIRM', 'MIRI_TACQ']:
+        kind[responsetable.columns['exp_type'] == ta_type] = 'TA'
+    kind[kind == ''] = 'SCI'
+    responsetable.add_column(astropy.table.Column(kind), index=2, name='kind')
+
+    if return_filenames:
+
+        if level is not None and level.lower() is not 'cal' and level.lower() is not '2b':
+            # Transform filenames to either rate or uncal files
+            # This may not be robust to all possible scenarios yet...
+            if level.lower()=='rate' or level.lower()=='2a':
+                responsetable['filename'] = [f.replace('_cal', '_rate') for f in responsetable['filename']]
+                responsetable['productLevel'] = '2a'
+            elif level.lower() == 'uncal' or level.lower() == '1b':
+                responsetable['filename'] = [f.replace('_calints', '_uncal').replace('_cal', '_uncal') for f in responsetable['filename']]
+                responsetable['productLevel'] = '1b'
+
+        return responsetable
+
     # Summarize the distinct observations conveniently.
     cols_to_keep = ['visit_id', 'filter', 'coronmsk', 'targname', 'obslabel',
                     'duration', 'numdthpt', 'program', 'title', 'pi_name']
-    
-    summarytable = astropy.table.Table([response.columns[cname].filled() for cname in cols_to_keep],
+
+    summarytable = astropy.table.Table([responsetable.columns[cname].filled() for cname in cols_to_keep],
                                        masked=False,
                                        copy=True)
-    
-    # Add the initial V to visit ID.
-    summarytable['visit_id'] = astropy.table.Column(summarytable['visit_id'], dtype=np.dtype('<U12'))
-    for row in summarytable:
-        row['visit_id'] = 'V' + row['visit_id']
-    
-    # Add a summary for which kind of observation each is.
-    kind = np.zeros(len(response), dtype='a3')
-    kind[:] = 'SCI'  # by default assume SCI, then check for REF and BKG
-    kind[response.columns['is_psf'] == 't'] = 'REF'
-    kind[response.columns['bkgdtarg'] == 't'] = 'BKG'
-    kind[kind == ''] = 'SCI'
-    summarytable.add_column(astropy.table.Column(kind), index=2, name='kind')
-    
-    summarytable.add_column(astropy.table.Column(astropy.time.Time(response['vststart_mjd'], format='mjd').iso, dtype=np.dtype('<U16')),
+
+    summarytable.add_column(astropy.table.Column(astropy.time.Time(responsetable['vststart_mjd'], format='mjd').iso, dtype=np.dtype('<U16')),
                             index=1,
                             name='start time')
-    
+
     summarytable = astropy.table.unique(summarytable)
     summarytable.sort(keys='start time')
-    
+
     return summarytable
+
+
+def get_mast_filename(filename, outputdir='.',
+                      overwrite=False, exists_ok=True,
+                      progress=False, verbose=True,
+                      mast_api_token=None):
+    """Download any specified filename from MAST, writing to outputdir
+
+    If a file exists already, default is to not download.
+    Set overwrite=True to overwrite existing output file.
+    or set exists_ok=False to raise ValueError.
+
+    Set progress=True to show a progress bar.
+
+    verbose toggles on/off minor informative text output
+
+    Other parameters are less likely to be useful:
+    Default mast_api_token comes from MAST_API_TOKEN environment variable.
+
+    Adapted from example code originally by Rick White, STScI, via archive help desk.
+    """
+
+    if not mast_api_token:
+        mast_api_token = os.environ.get('MAST_API_TOKEN')
+        if mast_api_token is None:
+            raise ValueError("Must define MAST_API_TOKEN env variable or specify mast_api_token parameter")
+    assert '/' not in filename, "Filename cannot include directories"
+
+    mast_url = "https://mast.stsci.edu/api/v0.1/Download/file"
+
+    if not os.path.exists(outputdir):
+        os.makedirs(outputdir)
+    elif not os.path.isdir(outputdir):
+        raise ValueError(f"Output location {outputdir} is not a directory")
+    elif not os.access(outputdir, os.W_OK):
+        raise ValueError(f"Output directory {outputdir} is not writable")
+    outfile = os.path.join(outputdir, filename)
+
+    if (not overwrite) and os.path.exists(outfile):
+        if exists_ok:
+            if verbose:
+                print(" ALREADY DOWNLOADED: "+outfile)
+            return
+        else:
+            raise ValueError(f"{outfile} exists, not overwritten")
+
+    r = requests.get(mast_url, params=dict(uri=f"mast:JWST/product/{filename}"),
+                     headers=dict(Authorization=f"token {mast_api_token}"), stream=True)
+    r.raise_for_status()
+
+    total_size_in_bytes = int(r.headers.get('content-length', 0))
+    block_size = 1024000
+    if progress:
+        progress_bar = tqdm(total=total_size_in_bytes, unit='iB', unit_scale=True)
+        csize = 0
+    with open(outfile, 'wb') as fd:
+        for data in r.iter_content(chunk_size=block_size):
+            fd.write(data)
+            if progress:
+                # use the size before uncompression
+                dsize = r.raw.tell()-csize
+                progress_bar.update(dsize)
+                csize += dsize
+    if progress:
+        progress_bar.close()
+        if total_size_in_bytes != 0 and progress_bar.n != total_size_in_bytes:
+            print("ERROR, something went wrong")
+    if verbose:
+        print(" DOWNLOAD SUCCESSFUL: "+outfile)
+
+
+def download_files(product_table, outputdir='.', verbose=True, **kwargs):
+    """Retrieve data products from MAST
+
+    Parameters
+    ----------
+    product_table : astropy.table
+        Table of MAST products, as returned by astroquery.Mast
+    outputdir : str
+        Directory where to save the output products
+    verbose : bool
+        Toggle text information output
+
+    Other kwargs are passed to get_mast_filename
+
+    """
+
+    # depending on which mast service is used, the filename column is inconsistently labeled
+    # in particular the Observations search vs. keyword search interfaces.
+    # in returned products
+    if 'filename' in product_table.colnames:
+        fn_key = 'filename'
+    elif 'productFilename' in product_table.colnames:
+        fn_key = 'productFilename'
+    else:
+        raise RuntimeError("Cannot find filename column in that table")
+
+    product_table.sort(keys=fn_key)
+
+    for row in product_table:
+        if verbose:
+            if 'size' in row.colnames:
+                print(f"{row[fn_key]} : {row['size']/(1024**2):.2f} MB")
+        get_mast_filename(row[fn_key], outputdir=outputdir, verbose=verbose,
+                          **kwargs)


### PR DESCRIPTION
This PR enhances the `mast.query_coron_datasets` function to allow querying on more parameters, and to optionally return a more detailed table including individual filenames (The prior behavior to return a shorter summary table remains the default). 

In addition there is a new `download_files` function that retrieves from MAST based on the query results. 

Example usage: 

```
> table = spaceKLIP.mast.query_coron_datasets('NIRCam', program=1386, filt='F444W', kind='SCI', 
                                              return_filenames=True, level='uncal')

> spaceKLIP.mast.download_files(table)

DOWNLOAD SUCCESSFUL: ./jw01386002001_0310a_00001_nrcalong_uncal.fits
DOWNLOAD SUCCESSFUL: ./jw01386003001_0310a_00001_nrcalong_uncal.fits
```