### PR TITLE
minor fixes & enhancements while testing the tutorial notebook

### DIFF
--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -1278,12 +1278,14 @@ def create_database(output_dir,
                     bgpaths=None,
                     assoc_using_targname=True,
                     verbose=True,
+                    readlevel3=False,
                     **kwargs):
 
     """ Create a spaceKLIP database from JWST data
 
     Automatically searches for uncal.fits in the input directory and creates 
-    a database of the JWST data. Only works for stage0, stage1, or stage2 data.
+    a database of the JWST data. Only works for stage0, stage1, or stage2 data
+    by default; set readlevel3=True to read in stage 3 outputs.
 
     Parameters
     ----------
@@ -1326,6 +1328,9 @@ def create_database(output_dir,
         Name of aperture (e.g., NRCA5_FULL)
     apername_pps : str
         Name of aperture from PPS (e.g., NRCA5_FULL)
+    readlevel3 : bool
+        Set this to invoke the code for re-reading in level 3 output
+        products. By default, only levels 0,1,2 data will be read and indexed.
     """
 
     from webbpsf_ext.imreg_tools import get_files
@@ -1346,9 +1351,17 @@ def create_database(output_dir,
     # Initialize the spaceKLIP database and read the input FITS files.
     db = Database(output_dir=output_dir)
     db.verbose = verbose
-    db.read_jwst_s012_data(datapaths=datapaths,
-                           psflibpaths=psflibpaths,
-                           bgpaths=bgpaths,
-                           assoc_using_targname=assoc_using_targname)
-    
+
+    if readlevel3:
+        db.read_jwst_s3_data(datapaths=datapaths,
+                             psflibpaths=psflibpaths,
+                             bgpaths=bgpaths,
+                             assoc_using_targname=assoc_using_targname)
+
+    else:
+        db.read_jwst_s012_data(datapaths=datapaths,
+                               psflibpaths=psflibpaths,
+                               bgpaths=bgpaths,
+                               assoc_using_targname=assoc_using_targname)
+
     return db

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -1906,7 +1906,7 @@ class ImageTools():
                                                               model_psf * masksub,
                                                               upsample_factor=1000,
                                                               normalization=None,
-                                                              return_error=False)
+                                                              return_error=True)
             yshift, xshift = shift
             
             # Update star position.

--- a/spaceKLIP/plotting.py
+++ b/spaceKLIP/plotting.py
@@ -250,7 +250,7 @@ def display_coron_image(filename):
     bpmask = np.zeros_like(image) + np.nan
     # does this file have DQ extension or not? PyKLIP outputs do not
     if is_pyklip:
-        bpmask[np.isfinite(image)] = 0
+        bpmask[np.isnan(image)] = 1
     else:
         bpmask[(model.dq[0] & 1) == True] = 1
         

--- a/spaceKLIP/plotting.py
+++ b/spaceKLIP/plotting.py
@@ -169,6 +169,9 @@ def display_coron_image(filename):
     Display and annotate a coronagraphic image.
     
     Shows image on asinh scale along with some basic metadata, scale bar, and compass.
+
+    This display function is designed to flexibly adapt to several different kinds of input data,
+    including rate, rateints, cal, calints files. And pyKLIP's KLmode cubes.
     
     Parameters
     ----------
@@ -208,14 +211,14 @@ def display_coron_image(filename):
         if cube_ints:
             image = np.nanmean(model.data, axis=0)
             dq = model.dq[0]
-            nints = model.meta.nints
+            nints = model.meta.exposure.nints
         else:
             image = model.data
             dq = model.dq
         bunit = model.meta.bunit_data
         is_psf = model.meta.exposure.psf_reference
 
-        annotation_text = f"{model.meta.target.proposer_name}\n{model.meta.instrument.filter}, {model.meta.exposure.readpatt}:{model.meta.exposure.ngroups}:{model.meta.exposure.nints}\n{model.meta.exposure.effective_exposure_time:.2f} s",
+        annotation_text = f"{model.meta.target.proposer_name}\n{model.meta.instrument.filter}, {model.meta.exposure.readpatt}:{model.meta.exposure.ngroups}:{model.meta.exposure.nints}\n{model.meta.exposure.effective_exposure_time:.2f} s"
 
         try:
             wcs = model.meta.wcs
@@ -241,7 +244,7 @@ def display_coron_image(filename):
         if len(image.shape)==3:
             image = image[-1] # select the last KL mode
             wcs = wcs.dropaxis(2)  # drop the nints axis
-        annotation_text = f"pyKLIP results for {header['TARGPROP']}\n{header['FILTER']}\n",
+        annotation_text = f"pyKLIP results for {header['TARGPROP']}\n{header['FILTER']}\n"
 
     
     bpmask = np.zeros_like(image) + np.nan
@@ -385,7 +388,7 @@ def plot_contrast_images(meta, data, data_masked, pxsc=None, savefile='./maskima
         extl = (data.shape[1]+1.)/2.*pxsc/1000. # arcsec
         extr = (data.shape[1]-1.)/2.*pxsc/1000. # arcsec
         extent = (extl, -extr, -extl, extr)
-        xlabel, ylabel = '$\Delta$RA [arcsec]', '$\Delta$Dec [arcsec]'
+        xlabel, ylabel = '$\\Delta$RA [arcsec]', '$\\Delta$Dec [arcsec]'
 
     # Initialize plots
     f, ax = plt.subplots(1, 2, figsize=(2*6.4, 1*4.8))


### PR DESCRIPTION
Some small edits while re-testing the NIRCam reduction notebook in preparation for testing the #91 PR. 

- fix error with return_error parameter for versions of skimage < 0.22
- enhance create_database func to allow reading in level 3 data, via a new `readlevel3=True` parameter that invokes `read_s3_data` if needed.
- Fix some minor bugs in the display functions that are used in that tutorial notebook