### PR TITLE
update readthedocs config on main

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,10 +5,12 @@ sphinx:
   configuration: docs/source/conf.py
 
 build:
-  image: latest
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
 
 python:
-  version: 3.8
+  version: 3.11
   install:
     - requirements: requirements.txt
     - requirements: requirements-dev.txt


### PR DESCRIPTION
I already implemented this change on develop in #104, but to get RTD working again we need this change on `main`, it turns out. 
Rather than waiting for whenever we next merge develop to main, it's better to just do this as a fix directly to main now. 