### PR TITLE
More RTD config debugging

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -10,7 +10,6 @@ build:
     python: "3.11"
 
 python:
-  version: 3.11
   install:
     - requirements: requirements.txt
     - requirements: requirements-dev.txt


### PR DESCRIPTION
remove unnecessary/deprecated python.version parameter, based on error message from latest RTD build. 