### PR TITLE
more readthedocs config debugging

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,9 +23,13 @@ import sys
 import matplotlib
 matplotlib.use("agg")
 
-import spaceKLIP
-
-version = spaceKLIP.__version__
+# Read in package version, without importing this package directly
+# (to avoid needing to install all the webbpsf datafiles as part of the readthedocs build)
+# This might also use sphinx-pyproject eventually, tbd
+from pkg_resources import get_distribution
+version = get_distribution('spaceKLIP').version
+#import spaceKLIP
+#version = spaceKLIP.__version__
 
 # -- General configuration ------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be


### PR DESCRIPTION
In docs conf.py, use pkg_resources  to avoid package import which would needs all webbpsf data files etc. Currently, the import spaceKLIP part is erroring out on RTD for not having those data files. 