### PR TITLE
Improving formatting for readthedocs tutorial notebooks

### DIFF
--- a/docs/source/_static/wider_docs.css
+++ b/docs/source/_static/wider_docs.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+max-width: 1200px !important;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,14 @@ templates_path = []#['./_templates']
 # mock imports for autodoc
 autodoc_mock_imports = ["webbpsf"]
 
+# nbsphinx settings
+nbsphinx_allow_errors = True
+nbsphinx_execute = 'never'
+nbsphinx_prolog = """
+{% set docname = env.doc2path(env.docname, base=None) %}
+.. note::  `Download the full notebook for this tutorial here <https://github.com/kammerje/spaceKLIP/tree/develop/docs/source/{{ docname }}>`_
+"""
+
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
@@ -225,6 +233,8 @@ html_logo = '_static/logo.png'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
+def setup(app):
+    app.add_css_file('wider_docs.css')
 html_static_path = ['./_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or

--- a/docs/source/tutorials/tutorial_MIRI_contrast_analyses.ipynb
+++ b/docs/source/tutorials/tutorial_MIRI_contrast_analyses.ipynb
@@ -11,7 +11,7 @@
     "from the JWST ERS program on Direct Observations of Exoplanetary Systems, program 1386. \n",
     "\n",
     "\n",
-    "<div class=\"alert alert-block alert-warning\">\n",
+    "<div class=\"alert alert-warning\">\n",
     "<b>Prerequisite:</b> This notebook assumes you have already ran the \"Tutorial for MIRI data reductions\" notebook. The output files  must be present from that reduction to be analyzed in this notebook.\n",
     "\n",
     "</div>"
@@ -431,7 +431,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/tutorial_MIRI_reductions.ipynb
+++ b/docs/source/tutorials/tutorial_MIRI_reductions.ipynb
@@ -12,11 +12,11 @@
     "\n",
     "\n",
     "\n",
-    "<div class=\"alert alert-block alert-success\">\n",
+    "<div class=\"alert alert-warning\">\n",
     "<b>Relation to other tutorials:</b> This notebook is intentionally very similar to the NIRCam data reduction notebook.  Subsequent analyses steps will be carried out in the MIRI post-pipeline analyses notebook. \n",
     "</div>\n",
     "\n",
-    "<div class=\"alert alert-block alert-info\">\n",
+    "<div class=\"alert alert-info\">\n",
     "<b>MIRI-specific information:</b> Steps and information specific to MIRI are called out in blue.</div>"
    ]
   },
@@ -70,31 +70,6 @@
    "metadata": {},
    "source": [
     "Note that currently the import of `webbpsf_ext` has a side effect of configuring extra verbose logging. We'll mostly ignore the output log text. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "040338d5",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<style>.container { width:100% !important; }</style>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "# Update notebook display to use full width of the window. This is a convenience for some of the large text output tables. \n",
-    "from IPython.display import display, HTML\n",
-    "display(HTML(\"<style>.container { width:100% !important; }</style>\"))"
    ]
   },
   {
@@ -551,7 +526,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "<div class=\"alert alert-block alert-info\">\n",
+    "<div class=\"alert alert-info\">\n",
     "<b>MIRI-specific information:</b> The following steps to update the coronagraph mask location is just required for MIRI right now. </div>\n",
     "\n",
     "\n",
@@ -641,7 +616,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "<div class=\"alert alert-block alert-info\">\n",
+    "<div class=\"alert alert-info\">\n",
     "<b>MIRI-specific information:</b> The bad pixel flagging for MIRI has a lot of manual adjustments as described below. </div>\n",
     "\n",
     "\n",
@@ -1582,7 +1557,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/docs/source/tutorials/tutorial_NIRCam_contrast_analyses.ipynb
+++ b/docs/source/tutorials/tutorial_NIRCam_contrast_analyses.ipynb
@@ -11,7 +11,7 @@
     "from the JWST ERS program on Direct Observations of Exoplanetary Systems, program 1386. \n",
     "\n",
     "\n",
-    "<div class=\"alert alert-block alert-warning\">\n",
+    "<div class=\"alert alert-warning\">\n",
     "<b>Prerequisite:</b> This notebook assumes you have already ran the \"Tutorial for NIRCam data reductions\" notebook. The output files  must be present from that reduction to be analyzed in this notebook.\n",
     "\n",
     "</div>"
@@ -315,9 +315,7 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "56c46ea7",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -616,9 +614,7 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "2e03494f",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -1439,7 +1435,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adding a few changes to the readthedocs:

- Wider column width so images display properly / things aren't so condensed. 
- Adding direct links to tutorial notebooks at the top of each tutorial page
- Adjust tutorial alert blocks following: https://nbsphinx.readthedocs.io/en/0.9.3/markdown-cells.html
- Removing notebook display adjustment that caused images to not appear / be replaced by whitespace. 