### PR TITLE
Avoid changing matplotlib rcParams font size

### DIFF
--- a/examples/example_miri_sky_1386.py
+++ b/examples/example_miri_sky_1386.py
@@ -1,8 +1,11 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
+import matplotlib.pyplot as plt
 
+# Update the matplotlib plotting style
+from spaceKLIP import plotting
+plotting.load_plt_style()
 
 # =============================================================================
 # IMPORTS
@@ -13,11 +16,9 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 from spaceKLIP import database, coron1pipeline, coron2pipeline, coron3pipeline, pyklippipeline, imagetools, contrast
-
 
 # =============================================================================
 # MAIN

--- a/examples/example_nircam_sim_1441.py
+++ b/examples/example_nircam_sim_1441.py
@@ -1,7 +1,11 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
+import matplotlib.pyplot as plt
+
+# Update the matplotlib plotting style
+from spaceKLIP import plotting
+plotting.load_plt_style()
 
 
 # =============================================================================
@@ -13,7 +17,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 from spaceKLIP import database, coron1pipeline, coron2pipeline, coron3pipeline, pyklippipeline, imagetools, contrast

--- a/examples/example_nircam_sky_1386.py
+++ b/examples/example_nircam_sky_1386.py
@@ -1,7 +1,11 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
+import matplotlib.pyplot as plt
+
+# Update the matplotlib plotting style
+from spaceKLIP import plotting
+plotting.load_plt_style()
 
 
 # =============================================================================
@@ -13,7 +17,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 from spaceKLIP import database, coron1pipeline, coron2pipeline, coron3pipeline, pyklippipeline, imagetools, contrast

--- a/examples/example_nircam_sky_1441.py
+++ b/examples/example_nircam_sky_1441.py
@@ -1,7 +1,11 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
+import matplotlib.pyplot as plt
+
+# Update the matplotlib plotting style
+from spaceKLIP import plotting
+plotting.load_plt_style()
 
 
 # =============================================================================
@@ -13,7 +17,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 from spaceKLIP import database, coron1pipeline, coron2pipeline, coron3pipeline, pyklippipeline, imagetools, contrast

--- a/examples/example_niriss_sky_1093.py
+++ b/examples/example_niriss_sky_1093.py
@@ -1,7 +1,11 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
+import matplotlib.pyplot as plt
+
+# Update the matplotlib plotting style
+from spaceKLIP import plotting
+plotting.load_plt_style()
 
 
 # =============================================================================
@@ -13,7 +17,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 from spaceKLIP import database, imagetools, coron1pipeline, coron2pipeline, coron3pipeline, pyklippipeline, contrast

--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -11,10 +11,10 @@ import pdb
 import sys
 
 import astropy.io.fits as fits
+import matplotlib.pyplot as plt
 from astropy.table import Table
 import astropy.units as u
 
-import matplotlib.pyplot as plt
 from cycler import cycler
 import numpy as np
 
@@ -326,53 +326,57 @@ class AnalysisTools():
                 # Plot masked data.
                 klmodes = self.database.red[key]['KLMODES'][j].split(',')
                 fitsfile = os.path.join(output_dir, os.path.split(fitsfile)[1])
-                f = plt.figure(figsize=(6.4, 4.8))
-                ax = plt.gca()
-                xx = np.arange(data.shape[2]) - center[0]  # pix
-                yy = np.arange(data.shape[1]) - center[1]  # pix
-                extent = (-(xx[0] - 0.5) * pxsc_arcsec, -(xx[-1] + 0.5) * pxsc_arcsec, (yy[0] - 0.5) * pxsc_arcsec, (yy[-1] + 0.5) * pxsc_arcsec)
-                vmax = np.nanmax(data[-1])
-                ax.imshow(data[-1], origin='lower', cmap='inferno',
-                          norm=matplotlib.colors.SymLogNorm(vmin=-vmax, vmax=vmax, linthresh=vmax/100 ),
-                          extent=extent)
-                ax.set_xlabel(r'$\Delta$RA [arcsec]')
-                ax.set_ylabel(r'$\Delta$Dec [arcsec]')
-                ax.set_title(f'Masked data in {filt}, {psfsub_strategy} ({klmodes[-1]} KL)')
-                for r in [5,10]:
-                    ax.add_patch(matplotlib.patches.Circle((0,0), r, ls='--', facecolor='none', edgecolor='cyan', clip_on=True))
-                    ax.text(r, 0, f" {r}''", color='cyan')
-                import textwrap
-                ax.text(0.01, 0.99, textwrap.fill(os.path.basename(fitsfile), width=40),
-                                    transform=ax.transAxes, color='black', verticalalignment='top', fontsize=9)
-                plt.colorbar(mappable=ax.images[0], label=self.database.red[key]['BUNIT'][j])
-                plt.tight_layout()
-                plt.savefig(fitsfile[:-5] + '_masked.pdf')
+                with plt.style.context('spaceKLIP.sk_style'):
+                    fig = plt.figure(figsize=(6.4, 4.8))
+                    ax = plt.gca()
+                    xx = np.arange(data.shape[2]) - center[0]  # pix
+                    yy = np.arange(data.shape[1]) - center[1]  # pix
+                    extent = (-(xx[0] - 0.5) * pxsc_arcsec, -(xx[-1] + 0.5) * pxsc_arcsec, (yy[0] - 0.5) * pxsc_arcsec, (yy[-1] + 0.5) * pxsc_arcsec)
+                    vmax = np.nanmax(data[-1])
+                    ax.imshow(data[-1], origin='lower', cmap='inferno',
+                            norm=matplotlib.colors.SymLogNorm(vmin=-vmax, vmax=vmax, linthresh=vmax/100 ),
+                            extent=extent)
+                    ax.set_xlabel(r'$\Delta$RA [arcsec]')
+                    ax.set_ylabel(r'$\Delta$Dec [arcsec]')
+                    ax.set_title(f'Masked data in {filt}, {psfsub_strategy} ({klmodes[-1]} KL)')
+                    for r in [5,10]:
+                        ax.add_patch(matplotlib.patches.Circle((0,0), r, ls='--', facecolor='none', edgecolor='cyan', clip_on=True))
+                        ax.text(r, 0, f" {r}''", color='cyan')
+                    import textwrap
+                    ax.text(0.01, 0.99, textwrap.fill(os.path.basename(fitsfile), width=40),
+                                        transform=ax.transAxes, color='black', verticalalignment='top', fontsize=9)
+                    plt.colorbar(mappable=ax.images[0], label=self.database.red[key]['BUNIT'][j])
+                    plt.tight_layout()
+                    plt.savefig(fitsfile[:-5] + '_masked.pdf')
+                    plt.close(fig)
 
                 # Plot raw contrast.
                 klmodes = self.database.red[key]['KLMODES'][j].split(',')
                 fitsfile = os.path.join(output_dir, os.path.split(fitsfile)[1])
                 colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
                 mod = len(colors)
-                f = plt.figure(figsize=(6.4, 4.8))
-                ax = plt.gca()
-                for k in range(data.shape[0]):
-                    if mask is None:
-                        ax.plot(seps[k], cons[k], color=colors[k % mod], label=klmodes[k] + ' KL')
-                    else:
-                        ax.plot(seps[k], cons[k], color=colors[k % mod], alpha=0.3, ls='--')
-                        ax.plot(seps[k], cons_mask[k], color=colors[k % mod], label=klmodes[k] + ' KL')
-                ax.set_yscale('log')
-                ax.set_ylim([None,1])
-                if plot_xlim is not None:
-                    ax.set_xlim(plot_xlim)
-                ax.set_xlabel('Separation [arcsec]')
-                ax.set_ylabel(r'5-$\sigma$ contrast')
-                ax.legend(loc='upper right', ncols=3,
-                          title=None if mask is None else 'Dashed lines exclude coronagraph mask throughput',
-                          title_fontsize=10)
-                ax.set_title(f'Raw contrast in {filt}, {psfsub_strategy}')
-                plt.tight_layout()
-                plt.savefig(fitsfile[:-5] + '_rawcon.pdf')
+                with plt.style.context('spaceKLIP.sk_style'):
+                    fig = plt.figure(figsize=(6.4, 4.8))
+                    ax = plt.gca()
+                    for k in range(data.shape[0]):
+                        if mask is None:
+                            ax.plot(seps[k], cons[k], color=colors[k % mod], label=klmodes[k] + ' KL')
+                        else:
+                            ax.plot(seps[k], cons[k], color=colors[k % mod], alpha=0.3, ls='--')
+                            ax.plot(seps[k], cons_mask[k], color=colors[k % mod], label=klmodes[k] + ' KL')
+                    ax.set_yscale('log')
+                    ax.set_ylim([None,1])
+                    if plot_xlim is not None:
+                        ax.set_xlim(plot_xlim)
+                    ax.set_xlabel('Separation [arcsec]')
+                    ax.set_ylabel(r'5-$\sigma$ contrast')
+                    ax.legend(loc='upper right', ncols=3,
+                            title=None if mask is None else 'Dashed lines exclude coronagraph mask throughput',
+                            title_fontsize=10)
+                    ax.set_title(f'Raw contrast in {filt}, {psfsub_strategy}')
+                    plt.tight_layout()
+                    plt.savefig(fitsfile[:-5] + '_rawcon.pdf')
+                    plt.close(fig)
 
                 if output_filetype.lower()=='ecsv':
                     # Save outputs as astropy ECSV text tables
@@ -720,6 +724,7 @@ class AnalysisTools():
 
                 # Define some local utilty functions for plot setup.
                 # This makes the plotting code below less repetitive and more consistent
+                @plt.style.context('spaceKLIP.sk_style')
                 def standardize_plots_setup():
                     fig = plt.figure(figsize=(6.4, 4.8))
                     ax = plt.gca()
@@ -728,6 +733,7 @@ class AnalysisTools():
                     ax.set_prop_cycle(cc)
                     return fig, ax
 
+                @plt.style.context('spaceKLIP.sk_style')
                 def standardize_plots_annotate_save(ax, title="",
                                                     ylabel='Throughput',
                                                     xlim=plot_xlim,
@@ -761,6 +767,8 @@ class AnalysisTools():
                 standardize_plots_annotate_save(ax, title=f'Injected companions in {filt}, {psfsub_strategy}, all KL modes',
                                                 ylabel='Throughput',
                                                 filename=save_string + '_allKL_throughput.pdf')
+                plt.close(fig)
+
 
                 # Plot individual measurements for median KL mode
                 fig, ax = standardize_plots_setup()
@@ -780,6 +788,8 @@ class AnalysisTools():
                                                 title=f"Injected companions in {filt}, {psfsub_strategy}, for KL={klip_args['numbasis'][median_KL_index]}",
                                                 ylabel='Throughput',
                                                 filename=save_string + '_medKL_throughput.pdf')
+                plt.close(fig)
+
 
                 # Plot calibrated contrast curves
                 fig, ax = standardize_plots_setup()
@@ -796,6 +806,7 @@ class AnalysisTools():
                                                 title=f'Calibrated contrast in {filt}, {psfsub_strategy}',
                                                 ylabel='Contrast',
                                                 filename=save_string + '_calcon.pdf')
+                plt.close(fig)
 
                 # Plot calibrated contrast curves compared to raw
                 fig, ax = standardize_plots_setup()
@@ -812,6 +823,7 @@ class AnalysisTools():
                                                 title=f'Calibrated contrast vs Raw contrast in {filt}, {psfsub_strategy}',
                                                 ylabel='Contrast',
                                                 filename=save_string + '_calcon_vs_rawcon.pdf')
+                plt.close(fig)
 
     def extract_companions(self,
                            companions,
@@ -1319,13 +1331,13 @@ class AnalysisTools():
                             
                             # Plot the MCMC fit results.
                             path = os.path.join(output_dir_kl, key + '-corner_c%.0f' % (k + 1) + '.pdf')
-                            fma.make_corner_plot()
-                            plt.savefig(path)
-                            plt.close()
+                            fig = fma.make_corner_plot()
+                            fig.savefig(path)
+                            plt.close(fig)
                             path = os.path.join(output_dir_kl, key + '-model_c%.0f' % (k + 1) + '.pdf')
-                            fma.best_fit_and_residuals()
-                            plt.savefig(path)
-                            plt.close()
+                            fig = fma.best_fit_and_residuals()
+                            fig.savefig(path)
+                            plt.close(fig)
                             
                             # Write the MCMC fit results into a table.
                             flux_jy = fma.fit_flux.bestfit * guess_flux

--- a/spaceKLIP/classpsfsubpipeline.py
+++ b/spaceKLIP/classpsfsubpipeline.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/classpsfsubpipeline.py
+++ b/spaceKLIP/classpsfsubpipeline.py
@@ -165,14 +165,15 @@ def run_obs(database,
                     temp = np.ones_like(data)
                     temp[data > kwargs['mask_bright']] = 0
                     temp = (temp > 0.5) & (pxdq < 0.5)
-                    plt.figure()
-                    plt.imshow(data, origin='lower', vmin=0, vmax=50)
-                    plt.imshow(temp, origin='lower', cmap='Greys_r', alpha=0.5)
-                    plt.colorbar()
-                    plt.tight_layout()
-                    plt.savefig(os.path.join(output_dir, key + '_mask.pdf'))
-                    # plt.show()
-                    plt.close()
+                    with plt.style.context('spaceKLIP.sk_style'):
+                        plt.figure()
+                        plt.imshow(data, origin='lower', vmin=0, vmax=50)
+                        plt.imshow(temp, origin='lower', cmap='Greys_r', alpha=0.5)
+                        plt.colorbar()
+                        plt.tight_layout()
+                        plt.savefig(os.path.join(output_dir, key + '_mask.pdf'))
+                        # plt.show()
+                        plt.close()
                 else:
                     temp = None
                 

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -11,7 +11,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 from tqdm import trange

--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -11,7 +11,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 from tqdm import tqdm, trange

--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/coron3pipeline.py
+++ b/spaceKLIP/coron3pipeline.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/coron3pipeline.py
+++ b/spaceKLIP/coron3pipeline.py
@@ -11,7 +11,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 from jwst.pipeline import Detector1Pipeline, Image2Pipeline, Coron3Pipeline

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -12,7 +12,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 import copy

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/fnoise_clean.py
+++ b/spaceKLIP/fnoise_clean.py
@@ -404,6 +404,7 @@ class OneOverfStep(Step):
 
         return np.asarray(model_arr)
 
+    @plt.style.context('webbpsf_ext.wext_style')
     def quick_plot(self, image, mask, model, im_diff=None):
 
         fig, axes = plt.subplots(2,2, figsize=(8,8), sharex=True, sharey=True)

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -1813,6 +1813,7 @@ class ImageTools():
         
         pass
     
+    @plt.style.context('spaceKLIP.sk_style')
     def find_nircam_centers(self,
                             data0,
                             key,
@@ -1933,7 +1934,7 @@ class ImageTools():
         
         # Plot data, model PSF, and scene overview.
         if output_dir is not None:
-            f, ax = plt.subplots(1, 3, figsize=(3 * 6.4, 1 * 4.8))
+            fig, ax = plt.subplots(1, 3, figsize=(3 * 6.4, 1 * 4.8))
             ax[0].imshow(datasub, origin='lower', cmap='Reds')
             ax[0].contourf(masksub, levels=[0.00, 0.25, 0.50, 0.75], cmap='Greys_r', vmin=0., vmax=2., alpha=0.5)
             ax[0].set_title('1. SCI frame & transmission mask')
@@ -1963,11 +1964,12 @@ class ImageTools():
             plt.savefig(output_file)
             log.info(f" Plot saved in {output_file}")
             # plt.show()
-            plt.close()
+            plt.close(fig)
         
         # Return star position.
         return xc, yc, xshift, yshift
     
+    @plt.style.context('spaceKLIP.sk_style')
     def align_frames(self,
                      method='fourier',
                      align_algo='leastsq',
@@ -2122,7 +2124,7 @@ class ImageTools():
             
             # Plot science frame alignment.
             colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
-            f = plt.figure(figsize=(6.4, 4.8))
+            fig = plt.figure(figsize=(6.4, 4.8))
             ax = plt.gca()
             for index, j in enumerate(ww_sci):
                 ax.scatter(shifts_all[index][:, 0] * self.database.obs[key]['PIXSCALE'][j] * 1000, 
@@ -2150,12 +2152,12 @@ class ImageTools():
             output_file = os.path.join(output_dir, key + '_align_sci.pdf')
             plt.savefig(output_file)
             log.info(f" Plot saved in {output_file}")
-            plt.close()
+            plt.close(fig)
             
             # Plot reference frame alignment.
             if len(ww_ref) > 0:
                 colors = plt.rcParams['axes.prop_cycle'].by_key()['color']
-                f = plt.figure(figsize=(6.4, 4.8))
+                fig = plt.figure(figsize=(6.4, 4.8))
                 ax = plt.gca()
                 seen = []
                 reps = []
@@ -2202,5 +2204,5 @@ class ImageTools():
                 output_file = os.path.join(output_dir, key + '_align_ref.pdf')
                 plt.savefig(output_file)
                 log.info(f" Plot saved in {output_file}")
-                plt.close()
+                plt.close(fig)
 

--- a/spaceKLIP/make_psfmasks.py
+++ b/spaceKLIP/make_psfmasks.py
@@ -11,7 +11,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 import json

--- a/spaceKLIP/make_psfmasks.py
+++ b/spaceKLIP/make_psfmasks.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/plotting.py
+++ b/spaceKLIP/plotting.py
@@ -35,6 +35,15 @@ log.setLevel(logging.INFO)
 # MAIN
 # =============================================================================
 
+def load_plt_style(style='spaceKLIP.sk_style'):
+    """
+    Load the matplotlib style for spaceKLIP plots.
+    
+    Load the style sheet in `sk_style.mplstyle`, which is a modified version of the
+    style sheet from the `webbpsf_ext` package.
+    """
+    plt.style.use(style)
+
 def annotate_compass(ax, image, wcs, xf=0.9, yf=0.1, length_fraction=0.07, color='white', fontsize=12, ):
     """
     Plot a compass annotation onto an image, to indicate North and East
@@ -164,6 +173,7 @@ def annotate_secondary_axes_arcsec(ax, image, wcs):
     secax.tick_params(labelsize='small')
     secay.tick_params(labelsize='small')
 
+@plt.style.context('spaceKLIP.sk_style')
 def display_coron_image(filename):
     """
     Display and annotate a coronagraphic image.
@@ -311,6 +321,7 @@ def display_coron_image(filename):
     # TODO:
     #   add second panel with zoom in on center
 
+@plt.style.context('spaceKLIP.sk_style')
 def display_coron_dataset(database, restrict_to=None, save_filename=None, stage3=None):
     """
     Display multiple files in a coronagraphic dataset.
@@ -372,7 +383,7 @@ def display_coron_dataset(database, restrict_to=None, save_filename=None, stage3
     if save_filename:
         pdf.close()
 
-
+@plt.style.context('spaceKLIP.sk_style')
 def plot_contrast_images(meta, data, data_masked, pxsc=None, savefile='./maskimage.pdf'):
     """
     Plot subtracted images to be used for contrast estimation, one with
@@ -424,6 +435,7 @@ def plot_contrast_images(meta, data, data_masked, pxsc=None, savefile='./maskima
 
     return
 
+@plt.style.context('spaceKLIP.sk_style')
 def plot_contrast_raw(meta, seps, cons, labels='default', savefile='./rawcontrast.pdf'):
     """
     Plot raw contrast curves for different KL modes.
@@ -463,6 +475,7 @@ def plot_contrast_raw(meta, seps, cons, labels='default', savefile='./rawcontras
 
     return
 
+@plt.style.context('spaceKLIP.sk_style')
 def plot_injected_locs(meta, data, transmission, seps, pas, pxsc=None, savefile='./injected.pdf'):
     '''
     Plot subtracted image and 2D transmission alongside locations of injected planets. 
@@ -523,7 +536,8 @@ def plot_injected_locs(meta, data, transmission, seps, pas, pxsc=None, savefile=
     plt.close()
 
     return
-            
+
+@plt.style.context('spaceKLIP.sk_style')
 def plot_contrast_calibrated(thrput, med_thrput, fit_thrput, con_seps, cons, corr_cons, savefile='./calcontrast.pdf'):
     '''
     Plot calibrated throughput alongside calibrated contrast curves. 
@@ -555,6 +569,7 @@ def plot_contrast_calibrated(thrput, med_thrput, fit_thrput, con_seps, cons, cor
 
     return
 
+@plt.style.context('spaceKLIP.sk_style')
 def plot_fm_psf(meta, fm_frame, data_frame, guess_flux, pxsc=None, j=0, savefile='./fmpsf.pdf'):
     '''
     Plot forward model psf
@@ -598,6 +613,7 @@ def plot_fm_psf(meta, fm_frame, data_frame, guess_flux, pxsc=None, j=0, savefile
 
     return
 
+@plt.style.context('spaceKLIP.sk_style')
 def plot_chains(chain, savefile):
     '''
     Plot MCMC chains from companion fitting
@@ -620,6 +636,7 @@ def plot_chains(chain, savefile):
     plt.savefig(savefile)
     plt.close()
 
+@plt.style.context('spaceKLIP.sk_style')
 def plot_subimages(imgdirs, subdirs, filts, submodes, numKL, 
                    window_size=2.5, cmaps_list=['viridis'],
                    imgVmin=[-40], imgVmax=[40], subVmin=[-10], subVmax=[10],

--- a/spaceKLIP/psf.py
+++ b/spaceKLIP/psf.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/psf.py
+++ b/spaceKLIP/psf.py
@@ -11,7 +11,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 import pysynphot as S

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/pyklippipeline.py
+++ b/spaceKLIP/pyklippipeline.py
@@ -11,7 +11,6 @@ import pdb
 import sys
 
 from astropy.io import fits 
-import matplotlib.pyplot as plt
 import numpy as np
 
 import json

--- a/spaceKLIP/sk_style.mplstyle
+++ b/spaceKLIP/sk_style.mplstyle
@@ -1,0 +1,37 @@
+# To use: 
+#   plt.style.use('spaceKLIP.sk_style')
+# 
+# Or: 
+#   with plt.style.context('spaceKLIP.sk_style'):
+#       plotting_functions()
+#
+# This also works:
+#   @plt.style.context('spaceKLIP.sk_style')
+#   def plotting_function(*args, **kwargs):
+#       plt.plot(*args, **kwargs)
+
+### Ticks
+xtick.minor.visible: True
+ytick.minor.visible: True
+xtick.direction: in
+ytick.direction: in
+xtick.top: True
+ytick.right: True 
+
+xtick.major.size: 6
+ytick.major.size: 6
+xtick.minor.size: 3
+ytick.minor.size: 3
+
+### Image orientation and aliasing
+image.interpolation: nearest
+image.origin: lower
+
+### Figure size
+figure.figsize: 8, 6
+
+### Fonts
+mathtext.fontset : cm
+font.family: serif
+# font.serif: cmr10  # To use Computer Modern Roman font
+font.size: 14

--- a/spaceKLIP/starphot.py
+++ b/spaceKLIP/starphot.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/starphot.py
+++ b/spaceKLIP/starphot.py
@@ -147,9 +147,10 @@ def get_stellar_magnitudes(starfile,
         # Fit SED to input photometry and plot SED.
         spec.fit_SED(x0=[1.], wlim=wlim, use_err=False, verbose=False)
         if output_dir is not None:
-            spec.plot_SED()
-            plt.savefig(os.path.join(output_dir, 'sed.pdf'))
-            plt.close()
+            with plt.style.context('spaceKLIP.sk_style'):
+                spec.plot_SED()
+                plt.savefig(os.path.join(output_dir, 'sed.pdf'))
+                plt.close()
         
         # Convert units to photlam.
         input_flux = u.Quantity(spec.sp_model.flux, str(spec.sp_model.fluxunits))

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -1,8 +1,6 @@
 from __future__ import division
 
 import matplotlib
-matplotlib.rcParams.update({'font.size': 14})
-
 
 # =============================================================================
 # IMPORTS

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -11,7 +11,6 @@ import pdb
 import sys
 
 import astropy.io.fits as pyfits
-import matplotlib.pyplot as plt
 import numpy as np
 
 import importlib


### PR DESCRIPTION
`import spaceKLIP` should not have side effects that unexpectedly change the appearance of plots produced by other non-spaceKLIP code. In particular we shouldn't hard-code overrides to a user's default matplotlib settings in rcParams. 

