### PR TITLE
multiprocess fix

### DIFF
--- a/spaceKLIP/fnoise_clean.py
+++ b/spaceKLIP/fnoise_clean.py
@@ -109,8 +109,8 @@ class OneOverfStep(Step):
 
         # If we are in a multiprocess thread, then set self.nproc to 1
         # to avoid nested multiprocessing.
-        # Spawned processes have a name like 'Process-1', 'Process-2', etc.
-        if 'Process-' in mp.current_process().name:
+        # Spawned processes have a name like 'Process-1', 'Process-2', etc. or 'PoolWorker-'
+        if ('Process-' in mp.current_process().name) or ('PoolWorker-' in mp.current_process().name):
             self.nproc = 1
             return
 


### PR DESCRIPTION
Quick fix to account for different naming conventions of multiprocess threads. Some versions of multiprocessing can spawn threads with the name "PoolWorker-N" as well as "Process-N". If we are already in such a spawned thread, then we should not run more new multiprocess threads. This expands the 1/f noise multiprocessing to check for such instances.