### PR TITLE
HOTFIX: Remove deprecated parameter from phase_cross_correlation

### DIFF
--- a/spaceKLIP/imagetools.py
+++ b/spaceKLIP/imagetools.py
@@ -1923,8 +1923,7 @@ class ImageTools():
             shift, error, phasediff = phase_cross_correlation(datasub * masksub,
                                                               model_psf * masksub,
                                                               upsample_factor=1000,
-                                                              normalization=None,
-                                                              return_error=True)
+                                                              normalization=None)
             yshift, xshift = shift
             
             # Update star position.


### PR DESCRIPTION
The `return_error` keyword has been removed from `phase_cross_correlation`:
https://scikit-image.org/docs/stable/api/skimage.registration.html#skimage.registration.phase_cross_correlation

Removing from our code too to avoid crashes. Previously we had this set to True, but it seems that this is returned regardless now, so no major changes needed. 