### PR TITLE
Formalising stsci.stimage requirement due to recent update issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ matplotlib
 numpy
 pysynphot
 scipy
+stsci.stimage==0.2.6
 webbpsf
 webbpsf_ext @ git+https://github.com/JarronL/webbpsf_ext.git@develop
 pyklip @ git+https://bitbucket.org/pyKLIP/pyklip.git@jwst_new


### PR DESCRIPTION
Edit: Sorry, not sure where the description went. 

stsci.stimage updated last week and the latest 0.2.7 version is causing our CI runs to crash due to failed import of a stsci.stimage function. I've looked at the update and don't see any major change or improvement that we should account for, so I think it makes sense to lock things at 0.2.6 until they push another update so that we can keep our updates moving. 

It seems they are already aware of the issue and have a PR in progress: https://github.com/spacetelescope/stsci.stimage/pull/37
