### PR TITLE
photlam units need to be in lowercase

### DIFF
--- a/spaceKLIP/starphot.py
+++ b/spaceKLIP/starphot.py
@@ -153,7 +153,7 @@ def get_stellar_magnitudes(starfile,
                 plt.close()
         
         # Convert units to photlam.
-        input_flux = u.Quantity(spec.sp_model.flux, str(spec.sp_model.fluxunits))
+        input_flux = u.Quantity(spec.sp_model.flux, str(spec.sp_model.fluxunits).lower())
         photlam_flux = convert_flux(spec.sp_model.wave, input_flux, out_flux_unit='photlam')
         sed = SourceSpectrum(Empirical1D, points=spec.sp_model.wave << u.Unit(str(spec.sp_model.waveunits)), lookup_table=photlam_flux << u.Unit('photlam'))
     


### PR DESCRIPTION
William: 

I'm getting an error in this line of starphot.get_stellar_magnitudes when trying to run extract_companions. I'm trying to figure out whether this is a bug I need to make an issue about or whether I've just mis-installed the new synphot/stsynphot/new webbpsf_ext.
input_flux = u.Quantity(spec.sp_model.flux, str(spec.sp_model.fluxunits))

ValueError: 'PHOTLAM' did not parse as unit
edit: input_flux = u.Quantity(spec.sp_model.flux, str(spec.sp_model.fluxunits).lower()) worked to fix this bug

Jarron:

yep, these are the fluxunits definitions in synphot.units:
# synphot flux units
PHOTLAM = u.def_unit(
    'photlam', u.photon / (u.cm**2 * u.s * u.AA),
    format={'generic': 'PHOTLAM', 'console': 'PHOTLAM'})
PHOTNU = u.def_unit(
    'photnu', u.photon / (u.cm**2 * u.s * u.Hz),
    format={'generic': 'PHOTNU', 'console': 'PHOTNU'})
FLAM = u.def_unit(
    'flam', u.erg / (u.cm**2 * u.s * u.AA),
    format={'generic': 'FLAM', 'console': 'FLAM'})
FNU = u.def_unit(
    'fnu', u.erg / (u.cm**2 * u.s * u.Hz),
    format={'generic': 'FNU', 'console': 'FNU'})