### PR TITLE
Determine crpix from saif toggle

### DIFF
--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -109,6 +109,7 @@ class Database():
                             datapaths,
                             psflibpaths=None,
                             bgpaths=None,
+                            cr_from_saif=False,
                             assoc_using_targname=True):
         """
         Read JWST stage 0 (*uncal), 1 (*rate or *rateints), or 2 (*cal or
@@ -274,8 +275,12 @@ class Database():
             BLURFWHM += [head.get('BLURFWHM', np.nan)]
             head = hdul['SCI'].header
             BUNIT += [head.get('BUNIT', 'NONE')]
-            CRPIX1 += [head.get('CRPIX1', np.nan)]
-            CRPIX2 += [head.get('CRPIX2', np.nan)]
+            if cr_from_saif:
+                CRPIX1 += [ap.XSciRef]
+                CRPIX2 += [ap.YSciRef]
+            else:
+                CRPIX1 += [head.get('CRPIX1', np.nan)]
+                CRPIX2 += [head.get('CRPIX2', np.nan)]
             VPARITY += [head.get('VPARITY', -1)]
             V3I_YANG += [head.get('V3I_YANG', 0.)]
             RA_REF += [head.get('RA_REF', np.nan)]
@@ -571,7 +576,8 @@ class Database():
         pass
     
     def read_jwst_s3_data(self,
-                          datapaths):
+                          datapaths,
+                          cr_from_saif=False):
         """
         Read JWST stage 3 data (this can be *i2d data from the official JWST
         pipeline, or data products from the pyKLIP and classical PSF
@@ -718,8 +724,12 @@ class Database():
             if TYPE[-1] == 'CORON3':
                 head = hdul['SCI'].header
             BUNIT += [head.get('BUNIT', 'NONE')]
-            CRPIX1 += [head.get('CRPIX1', np.nan)]
-            CRPIX2 += [head.get('CRPIX2', np.nan)]
+            if cr_from_saif:
+                CRPIX1 += [ap.XSciRef]
+                CRPIX2 += [ap.YSciRef]
+            else:
+                CRPIX1 += [head.get('CRPIX1', np.nan)]
+                CRPIX2 += [head.get('CRPIX2', np.nan)]
             HASH += [TELESCOP[-1] + '_' + INSTRUME[-1] + '_' + DETECTOR[-1] + '_' + FILTER[-1] + '_' + PUPIL[-1] + '_' + CORONMSK[-1] + '_' + SUBARRAY[-1]]
             hdul.close()
         TYPE = np.array(TYPE)
@@ -1277,6 +1287,7 @@ def create_database(output_dir,
                     assoc_using_targname=True,
                     verbose=True,
                     readlevel='012',
+                    cr_from_saif=False,
                     **kwargs):
 
     """ Create a spaceKLIP database from JWST data
@@ -1360,11 +1371,13 @@ def create_database(output_dir,
         db.read_jwst_s012_data(datapaths=datapaths,
                                psflibpaths=psflibpaths,
                                bgpaths=bgpaths,
+                               cr_from_saif=cr_from_saif,
                                assoc_using_targname=assoc_using_targname)
     elif str(readlevel) == '3':
         # the above get_files usage won't match KLIP outputsa, so find them here
         datapaths_klip = sorted(glob.glob(os.path.join(input_dir, "*KLmodes-all.fits")))
         db.read_jwst_s3_data(datapaths=datapaths+datapaths_klip,
+                             cr_from_saif=cr_from_saif,
                             )
     elif str(readlevel) == '4':
         db.read_jwst_s4_data(datapaths=datapaths,

--- a/spaceKLIP/database.py
+++ b/spaceKLIP/database.py
@@ -109,7 +109,7 @@ class Database():
                             datapaths,
                             psflibpaths=None,
                             bgpaths=None,
-                            cr_from_saif=False,
+                            cr_from_siaf=False,
                             assoc_using_targname=True):
         """
         Read JWST stage 0 (*uncal), 1 (*rate or *rateints), or 2 (*cal or
@@ -275,7 +275,7 @@ class Database():
             BLURFWHM += [head.get('BLURFWHM', np.nan)]
             head = hdul['SCI'].header
             BUNIT += [head.get('BUNIT', 'NONE')]
-            if cr_from_saif:
+            if cr_from_siaf:
                 CRPIX1 += [ap.XSciRef]
                 CRPIX2 += [ap.YSciRef]
             else:
@@ -577,7 +577,7 @@ class Database():
     
     def read_jwst_s3_data(self,
                           datapaths,
-                          cr_from_saif=False):
+                          cr_from_siaf=False):
         """
         Read JWST stage 3 data (this can be *i2d data from the official JWST
         pipeline, or data products from the pyKLIP and classical PSF
@@ -724,7 +724,7 @@ class Database():
             if TYPE[-1] == 'CORON3':
                 head = hdul['SCI'].header
             BUNIT += [head.get('BUNIT', 'NONE')]
-            if cr_from_saif:
+            if cr_from_siaf:
                 CRPIX1 += [ap.XSciRef]
                 CRPIX2 += [ap.YSciRef]
             else:
@@ -1287,7 +1287,7 @@ def create_database(output_dir,
                     assoc_using_targname=True,
                     verbose=True,
                     readlevel='012',
-                    cr_from_saif=False,
+                    cr_from_siaf=False,
                     **kwargs):
 
     """ Create a spaceKLIP database from JWST data
@@ -1371,13 +1371,13 @@ def create_database(output_dir,
         db.read_jwst_s012_data(datapaths=datapaths,
                                psflibpaths=psflibpaths,
                                bgpaths=bgpaths,
-                               cr_from_saif=cr_from_saif,
+                               cr_from_siaf=cr_from_siaf,
                                assoc_using_targname=assoc_using_targname)
     elif str(readlevel) == '3':
         # the above get_files usage won't match KLIP outputsa, so find them here
         datapaths_klip = sorted(glob.glob(os.path.join(input_dir, "*KLmodes-all.fits")))
         db.read_jwst_s3_data(datapaths=datapaths+datapaths_klip,
-                             cr_from_saif=cr_from_saif,
+                             cr_from_siaf=cr_from_siaf,
                             )
     elif str(readlevel) == '4':
         db.read_jwst_s4_data(datapaths=datapaths,


### PR DESCRIPTION
See discussion in #114 . For data affected by bad fits writing behavior, for instance, the NIRCam BAR/NARROW offset position, it might be necessary to toggle calling the CRPIX values from pysaif, as opposed to recording them from the headers. This affects the position of the mask and therefore the coronagraphic throughput. Default behavior is unchanged and the toggle is set to false. Added to the appropriate functions in `database.py`

Potential improvement could look to incorporate @JarronL 's `webbpsf_ext.imreg_tools.get_coron_apname` function in the default database building step, but this change is non-intrusive and sufficient for current reductions (unlike the original implementation in #114 ).