### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ astropy
 astroquery
 jwst
 matplotlib>=3.7.1
-numpy
+numpy<2
 synphot
 stsynphot
 scipy


### PR DESCRIPTION
Recent numpy 2.0.0 is breaking things (see #186 ) for new installations and CIs. It will probably require some extra work to follow the mitigation strategy (https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-2-migration-guide) but for now, we can maintain our existing set up with this requirement update.