### PR TITLE
update default exclusion radius units

### DIFF
--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -1297,9 +1297,9 @@ class AnalysisTools():
                     else:
                         dr = kwargs['dr']
                     if 'exclr' not in kwargs.keys() or kwargs['exclr'] is None:
-                        exclr = 3
+                        exclr = 3*resolution
                     else:
-                        exclr = kwargs['exclr']
+                        exclr = kwargs['exclr']*resolution
                     if 'xrange' not in kwargs.keys() or kwargs['xrange'] is None:
                         xrange = 2.
                     else:


### PR DESCRIPTION
just a quick update to return the "resolution" variable units to exclusion radius expression. having too large of an exclr term will return errors when sampling otherwise. sorry for missing this in the previous analysistools update PR!