### PR TITLE
Resolving deprecation of Step.closeout() method

### DIFF
--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -714,7 +714,11 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
             '\nException: {}'.format(e)
         )
     finally:
-        pipeline.closeout()
+        try:
+            pipeline.closeout()
+        except AttributeError:
+            # Method deprecated as of stpipe version 0.6.0
+            pass
 
     if isinstance(res, list):
         res = res[0]

--- a/spaceKLIP/coron2pipeline.py
+++ b/spaceKLIP/coron2pipeline.py
@@ -224,7 +224,11 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
             '\nException: {}'.format(e)
         )
     finally:
-        pipeline.closeout()
+        try: 
+            pipeline.closeout()
+        except AttributeError:
+            # Method deprecated as of stpipe version 0.6.0
+            pass
 
     if isinstance(res, list):
         res = res[0]

--- a/spaceKLIP/utils.py
+++ b/spaceKLIP/utils.py
@@ -16,7 +16,7 @@ import numpy as np
 import importlib
 import scipy.ndimage.interpolation as sinterp
 
-from scipy.integrate import simps
+from scipy.integrate import simpson
 from scipy.ndimage import fourier_shift, gaussian_filter
 from scipy.ndimage import shift as spline_shift
 
@@ -654,8 +654,8 @@ def _get_tp_comsubst(instrume,
             # Compute COM substrate transmission averaged over the respective
             # filter profile.
             bandpass_throughput = np.interp(comsubst_wave, bandpass_wave, bandpass_throughput)
-            int_tp_bandpass = simps(bandpass_throughput, comsubst_wave)
-            int_tp_bandpass_comsubst = simps(bandpass_throughput * comsubst_throughput, comsubst_wave)
+            int_tp_bandpass = simpson(bandpass_throughput, comsubst_wave)
+            int_tp_bandpass_comsubst = simpson(bandpass_throughput * comsubst_throughput, comsubst_wave)
             tp_comsubst = int_tp_bandpass_comsubst / int_tp_bandpass
     
     # Return.


### PR DESCRIPTION
- JWST pipeline version 1.15.0 / stpipe 0.6.0 has removed the Step.closeout() function, which raises an AttributeError. This PR catches this if needed. 
- This PR also converts scipy.integrate.simps calls to scipy.integrate.simpson, as the naming has been changed. 

Resolves #197