### PR TITLE
default maximum_cores='none'

### DIFF
--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -714,7 +714,7 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
     pipeline.ramp_fit.suppress_one_group = kwargs.get('suppress_one_group', False)
     # Number of processor cores to use during ramp fitting process
     # 'none', 'quarter', 'half', or 'all'
-    pipeline.ramp_fit.maximum_cores      = kwargs.get('maximum_cores', 'quarter')
+    pipeline.ramp_fit.maximum_cores      = kwargs.get('maximum_cores', 'none')
 
     # Set parameters from step dictionary
     for key1 in steps.keys():

--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -589,7 +589,7 @@ def run_single_file(fitspath, output_dir, steps={}, verbose=False, **kwargs):
             Default: False.
         - ramp_fit/maximum_cores : str, optional
             max number of parallel processes to create during ramp fitting.
-            'none', 'quarter', 'half', or 'all'. Default: 'quarter'.
+            'none', 'quarter', 'half', or 'all'. Default: 'none'.
 
         The default is {}. 
     
@@ -803,7 +803,7 @@ def run_obs(database,
             Default: False.
         - ramp_fit/maximum_cores : str, optional
             max number of parallel processes to create during ramp fitting.
-            'none', 'quarter', 'half', or 'all'. Default: 'quarter'.
+            'none', 'quarter', 'half', or 'all'. Default: 'none'.
 
         Default is {}.
         Each of these parameters can be passed directly through `kwargs`.


### PR DESCRIPTION
Work around for known bug when performing multiprocessing with OLS_C fitting (https://github.com/spacetelescope/jwst/issues/8842 and https://github.com/spacetelescope/jwst/issues/8710) by defaulting to 1 python process during ramp fitting. In addition, this provides slightly better performance during the ramp-fitting process for the C-fitting routine:

- stage 1 pipeline v1.15.1 with maximum_cores='none': 2m57sec
- stage 1 pipeline v1.15.1 with maximum_cores='quarter': 3m15sec
- stage 1 pipeline v1.15.1 with maximum_cores='half': 3m22sec

It appears that memory transfer oveheads for python multiprocessing actually slows down the fitting process. The OLS_C functionality inherently utilizing native multiprocessing without having to spawn new threads and is overall much faster when number of python processes is set to 1 (ie., maximum_cores='none'). 

Fixes #219 