### PR TITLE
Ensure maxnumbasis for cc is same as rc/klipsub

### DIFF
--- a/spaceKLIP/analysistools.py
+++ b/spaceKLIP/analysistools.py
@@ -638,7 +638,8 @@ class AnalysisTools():
                 klip_args['subsections'] = self.database.red[key]['SUBSECTS'][j]
                 klip_args['numbasis'] = [int(nb) for nb in self.database.red[key]['KLMODES'][j].split(',')]
                 klip_args['algo'] = 'klip' #Currently not logged, may need changing in future. 
-                klip_args['maxnumbasis'] = np.max(klip_args['numbasis'])
+                _, _, maxnumbasis = get_pyklip_filepaths(self.database, key, return_maxbasis=True) # ensure maxnumbasis is same as for rawcon / klipsub reduction 
+                klip_args['maxnumbasis'] = maxnumbasis
                 inj_subdir = klip_args['mode'] + '_NANNU' + str(klip_args['annuli']) \
                             + '_NSUBS' + str(klip_args['subsections']) + '_' + key +'/'
                 klip_args['movement'] = 1 #Currently not logged, fix later. 


### PR DESCRIPTION
In AnalysisTools.calibrate_contast(), maxnumbasis is set as np.max(KL_modes), which in some cases is different than in pyklippipeline.get_pyklip_filepaths() where it is np.sum(nints), because some users may set their list of KL modes necessarily smaller than the max ints, but still find better contrast when constructing the i_th KL with a large number of  images. 

This fix simply implements get_pyklip_filepaths in calibrate_contrast to set maxnumbasis.