### PR TITLE
mask given num of groups from any s1 sci/ref

### DIFF
--- a/spaceKLIP/coron1pipeline.py
+++ b/spaceKLIP/coron1pipeline.py
@@ -939,6 +939,10 @@ def run_obs(database,
                                                                fitspath, 
                                                                fitstype,
                                                                quiet)
+                    elif steps['mask_groups']['mask_method'] == 'custom':
+                        steps = prepare_group_masking_custom(steps,
+                                                            database.obs[key], 
+                                                            quiet)
                 else:
                     # Even though we are using mask_groups, this particular file will not have any groups masked
                     # Instruct to skip the step, but keep a record using skip_revert so we can undo for the next file.
@@ -1077,9 +1081,49 @@ def prepare_group_masking_basic(steps, observations, quiet=False):
 
         # Assign to steps so this stage doesn't get repeated. 
         steps['mask_groups']['mask_array'] = mask_array
-        print(mask_array)
 
     return steps
+
+
+def prepare_group_masking_custom(steps, observations, quiet=False):
+
+    if 'mask_array' not in steps['mask_groups']:
+        '''First time in the file loop, or groups_to_mask has been preset, 
+        run the optimisation and set groups to mask. '''
+        if not quiet: 
+            log.info('  --> Coron1Pipeline: Masking custom number of groups in ramp')
+
+        if 'custom_group' not in steps['mask_groups']:
+            raise KeyError('mask_method "custom" requires you to set the "custom_group" keyword argument in the "mask_groups" step.')
+
+        # Get science frames and reference cubes
+        sci_frames = []
+        ref_cubes = []
+        nfitsfiles = len(observations)
+        for j in range(nfitsfiles):
+            if observations['TYPE'][j] == 'SCI':
+                with fits.open(os.path.abspath(observations['FITSFILE'][j])) as hdul:
+                    sci_frame = hdul['SCI'].data[:, -1, :, :].astype(float)
+                    sci_frames.append(sci_frame)
+            elif observations['TYPE'][j] == 'REF':
+                with fits.open(os.path.abspath(observations['FITSFILE'][j])) as hdul:
+                    ref_cube = hdul['SCI'].data.astype(float)
+                    ref_shape = ref_cube.shape
+                    ref_cubes.append(ref_cube)
+
+        # Assemble array of groups to mask, starting one above the max group
+        final_max_grp_to_use = int(steps['mask_groups']['custom_group']) 
+        groups_to_mask = np.arange(final_max_grp_to_use+1, ref_cubes[0].shape[1])
+
+        # Make the mask array
+        mask_array = np.zeros(ref_shape, dtype=bool)
+        mask_array[:,groups_to_mask,:,:] = 1
+
+        # Assign to steps so this stage doesn't get repeated. 
+        steps['mask_groups']['mask_array'] = mask_array
+
+    return steps
+
 
 def prepare_group_masking_advanced(steps, observations, refpath, reftype, quiet=False):
 


### PR DESCRIPTION
I needed to trim off the last (saturated) group for a certain observation, so I added a simple function/option based on the mask groups routines to mask an arbitrary number of groups in science or reference images in stage one. It will operate on SCI or REF data.

Usage:

```

coron1pipeline.run_obs(database=Database,
                       steps={
                              'mask_groups': {
                                              'skip': False, 
                                              'mask_method': 'custom',
                                              'custom_group':16, # must be some integer-like corresponding to the maximum group you'd like included in your stage1 reduction
                                                             },
)
```

